### PR TITLE
Generate module documentation

### DIFF
--- a/modules/common_repository/Makefile
+++ b/modules/common_repository/Makefile
@@ -1,0 +1,4 @@
+PLANS = $(wildcard *.tf)
+
+README.md: README.md.in $(PLANS)
+	(cat README.md.in; terraform-docs markdown .) > $@ || { rm -f $@; exit 1; }

--- a/modules/common_repository/README.md
+++ b/modules/common_repository/README.md
@@ -1,18 +1,6 @@
 # Innabox common repository configuration
 
-## Variables
-
-- `name` -- the name of the repository
-
-- `visibility` -- [optional] either `public` or `private`
-
-- `branch_protection` -- [optional] `true` (the default) to configure the default branch protection, `false` if you do not want branch protection configured.
-
-- `labels` -- [optional] Issue label definitions for this repository if you do not want the standard set. This is a list of objects with `name`, `color`, and `description` attributes.
-
-- `teams` -- [optional] A list of teams with access to the repository. The value is a list of objects with `team_id` and `permission` attributes.
-
-- `users` -- [optional] A list of users with access to the repository. The value is a list of objects with `team_id` and `permission` attributes.
+Create a repository with managed labels, permissions, and branch protection rules.
 
 ## Examples
 
@@ -41,3 +29,49 @@ module "repo_docs" {
   ]
 }
 ```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [github_branch_protection.repo_protection](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
+| [github_issue_label.repo_labels](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/issue_label) | resource |
+| [github_repository.repo](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
+| [github_repository_collaborators.repo_collaborators](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_collaborators) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_branch_protection"></a> [branch\_protection](#input\_branch\_protection) | Configure branch protection if true | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | Repository description | `string` | `""` | no |
+| <a name="input_is_template"></a> [is\_template](#input\_is\_template) | Set this to true if this is a template repository | `bool` | `false` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | List of labels to configure on the repository | <pre>list(object({<br/>    name        = string<br/>    color       = string<br/>    description = string<br/>  }))</pre> | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the repository | `string` | n/a | yes |
+| <a name="input_required_approvals"></a> [required\_approvals](#input\_required\_approvals) | Number of approvals required before merging a pull request | `number` | `1` | no |
+| <a name="input_required_status_checks"></a> [required\_status\_checks](#input\_required\_status\_checks) | A list of status checks that must pass before a PR can merge | `list(string)` | `[]` | no |
+| <a name="input_teams"></a> [teams](#input\_teams) | Teams with access to this repository | <pre>list(object({<br/>    team_id    = string<br/>    permission = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_use_public_template"></a> [use\_public\_template](#input\_use\_public\_template) | Use the public\_template repository as the template for a new repository | `bool` | `true` | no |
+| <a name="input_users"></a> [users](#input\_users) | Users with access to this repository | <pre>list(object({<br/>    username   = string<br/>    permission = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_visibility"></a> [visibility](#input\_visibility) | Repository visibility (public or private) | `string` | `"public"` | no |
+
+## Outputs
+
+No outputs.

--- a/modules/common_repository/README.md.in
+++ b/modules/common_repository/README.md.in
@@ -1,0 +1,31 @@
+# Innabox common repository configuration
+
+Create a repository with managed labels, permissions, and branch protection rules.
+
+## Examples
+
+### A very typical repository
+
+```
+module "repo_docs" {
+  source      = "./modules/common_repository"
+  name        = "docs"
+  description = "General documentation for the AI in a Box project"
+}
+```
+
+### A repository with a team collaborator
+
+```
+module "repo_docs" {
+  source      = "./modules/common_repository"
+  name        = "docs"
+  description = "General documentation for the AI in a Box project"
+  teams = [
+    {
+      team_id = "docs-workers"
+      permission = "push"
+    }
+  ]
+}
+```

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -1,27 +1,30 @@
 variable "name" {
-  type = string
+  description = "The name of the repository"
+  type        = string
 }
 
 variable "description" {
-  type    = string
-  default = ""
+  description = "Repository description"
+  type        = string
+  default     = ""
 }
 
 variable "required_approvals" {
+  description = "Number of approvals required before merging a pull request"
   type        = number
   default     = 1
-  description = "Number of approvals required before merging a pull request"
 }
 
 variable "required_status_checks" {
+  description = "A list of status checks that must pass before a PR can merge"
   type        = list(string)
   default     = []
-  description = "A list of status checks that must pass before a PR can merge"
 }
 
 variable "visibility" {
-  type    = string
-  default = "public"
+  description = "Repository visibility (public or private)"
+  type        = string
+  default     = "public"
   validation {
     error_message = "unknown visiblity: must be public or private"
     condition     = contains(["public", "private"], var.visibility)
@@ -29,11 +32,13 @@ variable "visibility" {
 }
 
 variable "branch_protection" {
-  type    = bool
-  default = true
+  description = "Configure branch protection if true"
+  type        = bool
+  default     = true
 }
 
 variable "labels" {
+  description = "List of labels to configure on the repository"
   type = list(object({
     name        = string
     color       = string


### PR DESCRIPTION
Use terraform-docs [1] to generate documentation for common_repository
module.

[1]: https://github.com/terraform-docs/terraform-docs
