### PR TITLE
Teach common_repository how to configure github pages

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -14,11 +14,41 @@ resource "github_repository" "repo" {
   dynamic "template" {
     # Use the public_template repository as a template unless the repository is
     # private or is a template
-    for_each = var.visibility == "private" ? [] : var.is_template ? [] : var.use_public_template ? [0] : []
+    for_each = var.visibility == "private" ? [] : var.is_template ? [] : var.use_public_template ? ["enabled"] : []
 
     content {
       owner      = "innabox"
       repository = "public_template"
+    }
+  }
+
+  # There are two `dynamic "pages"` blocks here to account for the fact that `source` is only required
+  # if `build_type` is "legacy". The `for_each` at the top of each block will only enable the block when
+  # the necessary conditions are met.
+  dynamic "pages" {
+
+    # enable this block if `pages` is not null and `build_type` is "legacy" (or null)
+    for_each = var.pages == null ? [] : var.pages.build_type == "legacy" || var.pages.build_type == null ? ["enabled"] : []
+
+    content {
+      source {
+        branch = var.pages.source.branch
+        path   = var.pages.source.path
+      }
+
+      cname      = var.pages.cname
+      build_type = var.pages.build_type
+    }
+  }
+
+  dynamic "pages" {
+
+    # enable this block if `pages` is not null and `build_type` is "workflow"
+    for_each = var.pages == null ? [] : var.pages.build_type == "workflow" ? ["enabled"] : []
+
+    content {
+      cname      = var.pages.cname
+      build_type = var.pages.build_type
     }
   }
 }

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -94,3 +94,24 @@ variable "vulnerability_alerts" {
   type        = bool
   default     = false
 }
+
+variable "pages" {
+  description = "Configuration for github pages"
+  type = object({
+    source = optional(object({
+      branch = string
+      path   = string
+    }))
+    build_type = optional(string, "legacy")
+    cname      = optional(string)
+  })
+  default = null
+
+  validation {
+    error_message = "build_type must be one of \"workflow\" or \"legacy\""
+    condition = var.pages == null ? true : (
+      var.pages.build_type == null ||
+      contains(["workflow", "legacy"], var.pages.build_type)
+    )
+  }
+}

--- a/repositories.tf
+++ b/repositories.tf
@@ -109,6 +109,10 @@ module "repo_fulfillment_api" {
       permission = "push"
     }
   ]
+
+  pages = {
+    build_type = "workflow"
+  }
 }
 
 module "repo_hypershift_cluster_config" {


### PR DESCRIPTION

This adds support to the common_repository module for configuring github
pages. See [1] for documentation on this element.

[1]: https://search.opentofu.org/provider/opentofu/github/v6.3.0/docs/resources/repository#github-pages-configuration

The second commit in this PR then utilizes this new feature to enable pages support in the fulfillment-api repository.