### PR TITLE
Make issues repository public

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -1,8 +1,10 @@
 module "repo_issues" {
-  source      = "./modules/common_repository"
-  name        = "issues"
-  visibility  = "private"
-  description = "Issues related to AI in a Box project"
+  source                 = "./modules/common_repository"
+  name                   = "issues"
+  visibility             = "public"
+  description            = "Issues related to AI in a Box project"
+  use_public_template    = false
+  all_members_permission = "push"
 }
 
 module "repo_docs" {


### PR DESCRIPTION
Now that we're using this for tracking our progress towards POC 1, we
should make this repository public -- both to be open about our work and to
make it possible to transfer issues to our other public repositories.
