### PR TITLE
Allow fulfillment-wg to admin common and CLI

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -192,7 +192,7 @@ module "repo_fulfillment_cli" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "push"
+      permission = "admin"
     }
   ]
 }
@@ -253,7 +253,7 @@ module "repo_fulfillment_common" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "push"
+      permission = "admin"
     }
   ]
 }


### PR DESCRIPTION
This patch changes the `fulfillment-common` and `fulfillment-cli` projects so that the members of the `fulfillment-wg` have administrator permissions. This is needed to configure secrets and other settings related to the the GitHub actions.