### PR TITLE
Adding new repos for refactor of cloudkit-aap

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -275,7 +275,7 @@ module "repo_osac_templates" {
   source      = "./modules/common_repository"
   visibility  = "public"
   name        = "osac-templates"
-  description = "Ansible roles for base/generic templates."
+  description = "OSAC base templates"
   teams = [
     {
       team_id    = "fulfillment-wg"
@@ -284,11 +284,11 @@ module "repo_osac_templates" {
   ]
 }
 
-module "repo_massopenscloud_templates" {
+module "repo_massopencloud_templates" {
   source      = "./modules/common_repository"
   visibility  = "public"
-  name        = "osac-massopenscloud-templates"
-  description = "MOC Specific templates of OSAC."
+  name        = "osac-massopencloud-templates"
+  description = "OSAC MOC-specific templates"
   teams = [
     {
       team_id    = "fulfillment-wg"

--- a/repositories.tf
+++ b/repositories.tf
@@ -270,3 +270,29 @@ module "repo_osac_test_infra" {
     }
   ]
 }
+
+module "repo_osac_templates" {
+  source      = "./modules/common_repository"
+  visibility  = "public"
+  name        = "osac-templates"
+  description = "Ansible roles for base/generic templates."
+  teams = [
+    {
+      team_id    = "fulfillment-wg"
+      permission = "push"
+    }
+  ]
+}
+
+module "repo_massopenscloud_templates" {
+  source      = "./modules/common_repository"
+  visibility  = "public"
+  name        = "osac-massopenscloud-templates"
+  description = "MOC Specific templates of OSAC."
+  teams = [
+    {
+      team_id    = "fulfillment-wg"
+      permission = "push"
+    }
+  ]
+}


### PR DESCRIPTION
This commit is part of innabox/issues#270 .  It is the new home destination for the OSAC templates.