### PR TITLE
Keep cloudkit installer module name to update existing project

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -223,7 +223,7 @@ module "repo_cloudkit_operator_config" {
   ]
 }
 
-module "repo_osac_installer" {
+module "repo_cloudkit_installer" {
   source      = "./modules/common_repository"
   visibility  = "public"
   name        = "osac-installer"


### PR DESCRIPTION
OpenTofu is failing because the repo_cloudkit_installer module was renamed when we really just wanted to change the project name reference from cloudkit-installer to osac-installer. This should update the existing project in place