### PR TITLE
MGMT-23354: Archive `fulfillment-api`, `api` and `common`

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -63,6 +63,7 @@ module "repo_public_template" {
 }
 
 module "repo_fulfillment_api" {
+  archived    = true
   source      = "./modules/common_repository"
   visibility  = "public"
   name        = "fulfillment-api"
@@ -150,6 +151,7 @@ module "repo_cloudkit_aap" {
 }
 
 module "repo_fulfillment_cli" {
+  archived    = true
   source      = "./modules/common_repository"
   visibility  = "public"
   name        = "fulfillment-cli"
@@ -211,6 +213,7 @@ module "repo_enhancement_proposals" {
 }
 
 module "repo_fulfillment_common" {
+  archived    = true
   source      = "./modules/common_repository"
   visibility  = "public"
   name        = "fulfillment-common"


### PR DESCRIPTION
This patch changes the configuration of the `fulfillment-api`, `fulfillment-common` and `fulfillment-cli` projects so that the are archived, as their code has been merged into the `fulfillment-service` project.

Related: https://issues.redhat.com/browse/MGMT-23354