### PR TITLE
MGMT-23354: Add `archived` variable to common repository module

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -1,5 +1,6 @@
 resource "github_repository" "repo" {
   name                 = var.name
+  archived             = var.archived
   visibility           = var.visibility
   description          = var.description
   auto_init            = true

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -1,3 +1,9 @@
+variable "archived" {
+  description = "Whether the repository is archived"
+  type        = bool
+  default     = false
+}
+
 variable "name" {
   description = "The name of the repository"
   type        = string


### PR DESCRIPTION
A previous patch added the `archived = true` setting to some repositories, but that isn't actually supported by the `common_repository` module. This means that applying the configuration fails. This patch addresses that adding support for the `archived` attribute to the `common_repository` module.

Related: https://issues.redhat.com/browse/MGMT-23354