### PR TITLE
chore: Enable Ameya to be part of the github's osac-project org

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -43,3 +43,4 @@ CrystalChun,member
 danmanor,member
 omer-vishlitzky,member
 obochan-rh,member
+amej,member

--- a/team-members/fulfillment-wg.csv
+++ b/team-members/fulfillment-wg.csv
@@ -31,3 +31,4 @@ CrystalChun,member
 danmanor,member
 omer-vishlitzky,member
 obochan-rh,member
+amej,member


### PR DESCRIPTION
Adds github account of Ameya Sathe, OSAC project to OSAC team  member to enable him to be part of the github's osac-project org.

Pre-commit checks passed.
`git commit -sS -m 'chore: Adds github    main  Ameya, OSAC project to OSAC team as well as member of github-config for osac-project org'
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check json...........................................(no files to check)Skipped
check for broken symlinks............................(no files to check)Skipped
detect private key.......................................................Passed
yamllint.............................................(no files to check)Skipped
tofu-fmt.............................................(no files to check)Skipped
[main 3cc7037] chore: Adds github account of Ameya, OSAC project to OSAC team as well as member of github-config for osac-project org
`