### PR TITLE
MGMT-23698: Remove repo_osac_templates module configuration

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -215,23 +215,6 @@ module "repo_osac_test_infra" {
   ]
 }
 
-module "repo_osac_templates" {
-  source      = "./modules/common_repository"
-  visibility  = "public"
-  name        = "osac-templates"
-  description = "OSAC base templates"
-  teams = [
-    {
-      team_id    = "fulfillment-wg"
-      permission = "admin"
-    }
-  ]
-  required_approvals = null
-  required_status_checks = [
-    "ci/prow/temp"
-  ]
-}
-
 module "repo_massopencloud_templates" {
   source      = "./modules/common_repository"
   visibility  = "public"


### PR DESCRIPTION
Removed the 'repo_osac_templates' module configuration from repositories.tf.

`osac-templates` is now archived, and its content was moved to `osac-aap`. It was moved because it removes re-vendoring friction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed osac-templates repository configuration from managed infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->