### PR TITLE
Add the repo for host management operator - openstack

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -240,3 +240,16 @@ module "repo_osac_ui" {
     }
   ]
 }
+
+module "repo_host_management_openstack" {
+  source      = "./modules/common_repository"
+  visibility  = "public"
+  name        = "host-management-openstack"
+  description = "OSAC Host Management Operator for OpenStack"
+  teams = [
+    {
+      team_id    = "fulfillment-wg"
+      permission = "admin"
+    }
+  ]
+}


### PR DESCRIPTION
Related to https://github.com/osac-project/issues/issues/375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new public repository for the OSAC Host Management Operator for OpenStack.
  * Repository is publicly visible and configured with administrative access for the responsible team.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->