### PR TITLE
Rename repository from 'osac-ui' to 'osac-ui-experiment'

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -231,7 +231,7 @@ module "repo_massopencloud_templates" {
 module "repo_osac_ui" {
   source      = "./modules/common_repository"
   visibility  = "public"
-  name        = "osac-ui"
+  name        = "osac-ui-experiment"
   description = "OSAC UI Web Console"
   teams = [
     {


### PR DESCRIPTION
change the old osac-ui repo to experiment in order to add the current osac-ui to the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for the UI module, renaming the repository identifier to designate an experimental variant for separate development and tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/github-config/pull/78)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->