### PR TITLE
Add masayag to org members and fulfillment-wg team

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -64,3 +64,4 @@ thrasher-redhat,admin
 admbk,member
 souvdas-coder,member
 geizenbe,member
+masayag,member

--- a/team-members/fulfillment-wg.csv
+++ b/team-members/fulfillment-wg.csv
@@ -51,3 +51,4 @@ ygalblum,member
 liatb-rh,member
 souvdas-coder,member
 geizenbe,member
+masayag,member

--- a/team-members/observability-wg.csv
+++ b/team-members/observability-wg.csv
@@ -4,3 +4,4 @@ IsaiahStapleton,member
 oourfali,maintainer
 schwesig,member
 ajamias,member
+masayag,member


### PR DESCRIPTION
## Summary
   - Add masayag as a member to the main organization
   - Add masayag as a member to the fulfillment working group team

   ## Changes
   - Updated `members.csv` to include masayag as a member
   - Updated `team-members/fulfillment-wg.csv` to include masayag as a member