### PR TITLE
OSAC-1112: Enable GitHub Pages for the fulfillment-service repository

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -100,11 +100,13 @@ module "repo_fulfillment_service" {
       permission = "admin"
     }
   ]
-
   required_approvals = null
   required_status_checks = [
     "ci/prow/unit"
   ]
+  pages = {
+    build_type = "workflow"
+  }
 }
 
 module "repo_cloudkit_operator" {


### PR DESCRIPTION
## Summary

The `fulfillment-service` repository recently added a GitHub Actions workflow to publish
OpenAPI specifications to GitHub Pages (see osac-project/fulfillment-service#619). However,
the Pages feature was only enabled manually in the repository settings, so it gets reverted
every time this Terraform configuration is re-applied, because the `pages` variable defaults
to `null`.

This adds the `pages` configuration with `build_type = "workflow"` to match the workflow-based
deployment used by `publish-openapi.yaml`.

Related: https://redhat.atlassian.net/browse/OSAC-1112
Related: https://github.com/osac-project/fulfillment-service/pull/619

## Test plan

- [ ] Verify that `terraform plan` shows no unexpected changes beyond enabling Pages.
- [ ] After apply, confirm that GitHub Pages remains enabled on the `fulfillment-service` repository with `build_type = "workflow"`.
- [ ] Confirm the OpenAPI specs are still accessible at `https://osac-project.github.io/fulfillment-service/openapi/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for build and deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->