### PR TITLE
Enable GitHub Pages for the osac-workspace repository

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -280,4 +280,7 @@ module "repo_osac_workspace" {
       permission = "admin"
     }
   ]
+  pages = {
+    build_type = "workflow"
+  }
 }


### PR DESCRIPTION
## Summary

- The `osac-workspace` repository has a GitHub Actions workflow that publishes a PR dashboard to GitHub Pages
- Pages was only enabled manually in the repo settings, so it gets disabled every time Terraform is re-applied (causing the 404 at https://osac-project.github.io/osac-workspace/pr-dashboard/)
- This adds the `pages` configuration with `build_type = "workflow"` to persist the setting, matching what was done for `fulfillment-service` in #89

## Test plan

- [ ] Verify that `terraform plan` shows no unexpected changes beyond enabling Pages
- [ ] After apply, confirm GitHub Pages remains enabled on the `osac-workspace` repository with `build_type = "workflow"`
- [ ] Confirm the PR dashboard is accessible at `https://osac-project.github.io/osac-workspace/pr-dashboard/`

Related: #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured GitHub Pages with workflow-based build settings for the workspace repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->