### PR TITLE
Lock down main branch: no manual merges, no force push

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -79,6 +79,13 @@ resource "github_branch_protection" "repo_protection" {
     "osac-project/org-admins",
   ]
 
+  dynamic "restrict_pushes" {
+    for_each = var.push_allowances != null ? [1] : []
+    content {
+      push_allowances = var.push_allowances
+    }
+  }
+
   dynamic "required_pull_request_reviews" {
     for_each = var.required_approvals[*]
 

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -121,6 +121,16 @@ variable "pages" {
   }
 }
 
+variable "push_allowances" {
+  description = "Actors allowed to push to the protected branch. When set, restricts both direct pushes and PR merges to these actors only. Actor names must begin with '/' for users or 'org-name/' for teams."
+  type        = list(string)
+  default     = null
+  validation {
+    condition     = var.push_allowances == null || length(var.push_allowances) > 0
+    error_message = "push_allowances must be null (disabled) or a non-empty list of actors"
+  }
+}
+
 variable "all_members_permission" {
   description = "Permission for all organization members"
   type        = string

--- a/repositories.tf
+++ b/repositories.tf
@@ -98,6 +98,10 @@ module "repo_fulfillment_service" {
     {
       team_id    = "fulfillment-wg"
       permission = "push"
+    },
+    {
+      team_id    = "wg-infra"
+      permission = "push"
     }
   ]
   required_approvals = null
@@ -119,6 +123,10 @@ module "repo_cloudkit_operator" {
     {
       team_id    = "fulfillment-wg"
       permission = "push"
+    },
+    {
+      team_id    = "wg-infra"
+      permission = "push"
     }
   ]
 
@@ -138,6 +146,10 @@ module "repo_cloudkit_aap" {
   teams = [
     {
       team_id    = "fulfillment-wg"
+      permission = "push"
+    },
+    {
+      team_id    = "wg-infra"
       permission = "push"
     }
   ]
@@ -183,6 +195,10 @@ module "repo_osac_installer" {
     {
       team_id    = "fulfillment-wg"
       permission = "push"
+    },
+    {
+      team_id    = "wg-infra"
+      permission = "push"
     }
   ]
 
@@ -212,6 +228,10 @@ module "repo_osac_test_infra" {
   teams = [
     {
       team_id    = "fulfillment-wg"
+      permission = "push"
+    },
+    {
+      team_id    = "wg-infra"
       permission = "push"
     }
   ]

--- a/repositories.tf
+++ b/repositories.tf
@@ -168,7 +168,7 @@ module "repo_cloudkit_aap_ee" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
 }
@@ -181,7 +181,7 @@ module "repo_cloudkit_operator_config" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
 }
@@ -263,7 +263,7 @@ module "repo_osac_ui" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
 }
@@ -276,7 +276,7 @@ module "repo_host_management_openstack" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
 }
@@ -289,7 +289,7 @@ module "repo_bare_metal_operator" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
 }
@@ -302,7 +302,7 @@ module "repo_osac_workspace" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
   pages = {

--- a/repositories.tf
+++ b/repositories.tf
@@ -97,13 +97,14 @@ module "repo_fulfillment_service" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
   required_approvals = null
   required_status_checks = [
     "ci/prow/unit"
   ]
+  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra"]
   pages = {
     build_type = "workflow"
   }
@@ -117,7 +118,7 @@ module "repo_cloudkit_operator" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
 
@@ -126,6 +127,7 @@ module "repo_cloudkit_operator" {
   ]
 
   required_approvals = null
+  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra"]
 }
 
 module "repo_cloudkit_aap" {
@@ -136,13 +138,14 @@ module "repo_cloudkit_aap" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
   required_approvals = null
   required_status_checks = [
     "ci/prow/temp"
   ]
+  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra"]
 }
 
 module "repo_cloudkit_aap_ee" {
@@ -179,7 +182,7 @@ module "repo_osac_installer" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
 
@@ -189,6 +192,7 @@ module "repo_osac_installer" {
   ]
 
   required_approvals = null
+  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra"]
 }
 
 module "repo_enhancement_proposals" {
@@ -208,13 +212,14 @@ module "repo_osac_test_infra" {
   teams = [
     {
       team_id    = "fulfillment-wg"
-      permission = "admin"
+      permission = "push"
     }
   ]
   required_approvals = null
   required_status_checks = [
     "ci/prow/temp"
   ]
+  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra"]
 }
 
 module "repo_massopencloud_templates" {

--- a/team-members/fulfillment-wg.csv
+++ b/team-members/fulfillment-wg.csv
@@ -54,4 +54,4 @@ sruiz-rh,member
 geizenbe,member
 aalfanda,member
 batzionb,member
-rawagner, member
+rawagner,member

--- a/team-members/wg-infra.csv
+++ b/team-members/wg-infra.csv
@@ -1,0 +1,3 @@
+username,role
+eliorerz,member
+omer-vishlitzky,member

--- a/teams.csv
+++ b/teams.csv
@@ -4,3 +4,4 @@ fulfillment-wg,Fulfillment working group,secret
 observability-wg,observability working group,secret
 personas-wg,Personas working group,secret
 documentation-wg,Documentation working group,secret
+wg-infra,OSAC Infrastructure working group,closed


### PR DESCRIPTION
## Summary

- **Add `restrict_pushes`** on 5 core repos — only `openshift-merge-robot` (tide) and `wg-infra` are in the push allowlist. The GitHub merge button is disabled for everyone else.
- **Downgrade `fulfillment-wg` from `admin` to `push`** on all 5 core repos (OSAC-1280) — 54 people no longer have admin privileges that bypass branch protection.
- **Add `wg-infra` team** to Terraform (for OSAC-1322 /override restriction).

No changes to `enforce_admins` or `force_push_bypassers` — org-admins retain full emergency access.


## Affected repos

- osac-operator
- osac-installer
- osac-aap
- fulfillment-service
- osac-test-infra

## Before applying

The `wg-infra` team already exists on GitHub (created manually). Import it before `tofu apply`:
```
tofu import 'github_team.all["wg-infra"]' 17924779
```

Also remove `amej` from the team on GitHub — this PR defines only `eliorerz` and `omer-vishlitzky`.

## Related tickets

- [OSAC-1280](https://redhat.atlassian.net/browse/OSAC-1280) — Downgrade fulfillment-wg from admin to write
- [OSAC-1322](https://redhat.atlassian.net/browse/OSAC-1322) — Restrict /override to wg-infra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Branch protection now supports configurable push allowances to permit specific actors and automation to push or merge on protected branches.
  * Adjusted team permissions: the fulfillment team's role was changed from admin to push across multiple repositories, with explicit push allowances added for designated actors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->