### PR TITLE
NO-ISSUE: Add eliorerz as maintainer to documentation-wg and org-admins

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -28,7 +28,7 @@ jstacy28,member
 memalhot,member
 ajamias,member
 trewest,member
-eliorerz,member
+eliorerz,admin
 maorfr,member
 karmab,member
 schmaustech,member

--- a/team-members/documentation-wg.csv
+++ b/team-members/documentation-wg.csv
@@ -3,3 +3,4 @@ jstacy28,member
 tzumainn,maintainer
 larsks,maintainer
 memalhot,member
+eliorerz,maintainer

--- a/team-members/fulfillment-wg.csv
+++ b/team-members/fulfillment-wg.csv
@@ -15,7 +15,7 @@ maorfr,member
 mlorenzofr,member
 DanNiESh,member
 karmab,member
-eliorerz,member
+eliorerz,maintainer
 romfreiman,member
 schmaustech,member
 tzvatot,member

--- a/team-members/org-admins.csv
+++ b/team-members/org-admins.csv
@@ -2,3 +2,4 @@ username,role
 larsks,maintainer
 tzumainn,maintainer
 romfreiman,maintainer
+eliorerz,maintainer


### PR DESCRIPTION
## Summary
- Promote eliorerz from member to maintainer in fulfillment-wg
- Add eliorerz as maintainer to documentation-wg
- Add eliorerz as maintainer to org-admins

Matching the same role as larsks across all three teams.