### PR TITLE
OSAC-1280: Tighten repo permissions - rebase only, restrict push to org-admins and wg-infra

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -5,6 +5,9 @@ resource "github_repository" "repo" {
   description          = var.description
   auto_init            = true
   allow_auto_merge     = var.visibility == "private" ? false : true
+  allow_merge_commit   = var.allow_merge_commit
+  allow_squash_merge   = var.allow_squash_merge
+  allow_rebase_merge   = var.allow_rebase_merge
   has_issues           = true
   has_downloads        = false
   has_projects         = false

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -131,6 +131,24 @@ variable "push_allowances" {
   }
 }
 
+variable "allow_merge_commit" {
+  description = "Allow merge commits on pull requests"
+  type        = bool
+  default     = false
+}
+
+variable "allow_squash_merge" {
+  description = "Allow squash merging on pull requests"
+  type        = bool
+  default     = false
+}
+
+variable "allow_rebase_merge" {
+  description = "Allow rebase merging on pull requests"
+  type        = bool
+  default     = true
+}
+
 variable "all_members_permission" {
   description = "Permission for all organization members"
   type        = string

--- a/repositories.tf
+++ b/repositories.tf
@@ -108,7 +108,7 @@ module "repo_fulfillment_service" {
   required_status_checks = [
     "ci/prow/unit"
   ]
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra"]
+  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   pages = {
     build_type = "workflow"
     source = {
@@ -139,7 +139,7 @@ module "repo_cloudkit_operator" {
   ]
 
   required_approvals = null
-  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra"]
+  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
 }
 
 module "repo_cloudkit_aap" {
@@ -161,7 +161,7 @@ module "repo_cloudkit_aap" {
   required_status_checks = [
     "ci/prow/temp"
   ]
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra"]
+  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
 }
 
 module "repo_cloudkit_aap_ee" {
@@ -212,7 +212,7 @@ module "repo_osac_installer" {
   ]
 
   required_approvals = null
-  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra"]
+  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
 }
 
 module "repo_enhancement_proposals" {
@@ -243,7 +243,7 @@ module "repo_osac_test_infra" {
   required_status_checks = [
     "ci/prow/temp"
   ]
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra"]
+  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
 }
 
 module "repo_massopencloud_templates" {


### PR DESCRIPTION
## Summary
- **Enforce rebase-only merges**: Add `allow_merge_commit = false`, `allow_squash_merge = false`, `allow_rebase_merge = true` (defaults) to the common_repository module. This disables the merge commit and squash options on the GitHub merge button and for branch updates.
- **Restrict push allowances**: Replace `osac-project/wg-infra` with `osac-project/org-admins` in `push_allowances` on all 5 active repos (fulfillment-service, osac-operator, osac-aap, osac-installer, osac-test-infra). Only `openshift-merge-robot` (Tide) and org-admins can merge via the GitHub button.

## Affected repos
- fulfillment-service
- osac-operator
- osac-aap
- osac-installer
- osac-test-infra

## What changes for users
- Regular contributors (fulfillment-wg, wg-infra with write access): no change to normal workflow (`/lgtm` + `/approve` → Tide merge). They can no longer merge via the GitHub button.
- org-admins: can still merge via GitHub button and force-push when needed.
- All repos: only rebase merge is allowed (merge commits and squash disabled).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced configurable pull request merge strategy controls for repositories. Teams can now independently configure which merge methods—merge commits, squash merges, and rebase merges—are permitted for each repository, supporting diverse project workflows and team preferences.

* **Chores**
  * Updated repository access control configurations to improve overall permission management and security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->