### PR TITLE
Upgrade wg-infra from push to admin

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -101,7 +101,7 @@ module "repo_fulfillment_service" {
     },
     {
       team_id    = "wg-infra"
-      permission = "push"
+      permission = "admin"
     }
   ]
   required_approvals = null
@@ -126,7 +126,7 @@ module "repo_cloudkit_operator" {
     },
     {
       team_id    = "wg-infra"
-      permission = "push"
+      permission = "admin"
     }
   ]
 
@@ -150,7 +150,7 @@ module "repo_cloudkit_aap" {
     },
     {
       team_id    = "wg-infra"
-      permission = "push"
+      permission = "admin"
     }
   ]
   required_approvals = null
@@ -198,7 +198,7 @@ module "repo_osac_installer" {
     },
     {
       team_id    = "wg-infra"
-      permission = "push"
+      permission = "admin"
     }
   ]
 
@@ -232,7 +232,7 @@ module "repo_osac_test_infra" {
     },
     {
       team_id    = "wg-infra"
-      permission = "push"
+      permission = "admin"
     }
   ]
   required_approvals = null


### PR DESCRIPTION
Admin privileges are required to override branch protection restrictions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Elevated a team's repository permissions from "push" to "admin" across several repositories to broaden access level.
  * Confirmed no changes were made to pages/deployment configuration in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->