### PR TITLE
Do not restrict merge types by default

### DIFF
--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -134,13 +134,13 @@ variable "push_allowances" {
 variable "allow_merge_commit" {
   description = "Allow merge commits on pull requests"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "allow_squash_merge" {
   description = "Allow squash merging on pull requests"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "allow_rebase_merge" {


### PR DESCRIPTION
The changes in #98 restricted regular merges and squash merges. This has
caused problems with CI because tide is attempting to create merge commits.

This change sets the default value for alllow_merge_commit and
allow_squash_merge to `true` pending further discussion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Updated default merge strategy settings. Commit merge and squash merge capabilities are now enabled by default in repository configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->