### PR TITLE
OSAC-1568: Add e2e-test GitHub environment to osac-test-infra

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -105,6 +105,34 @@ resource "github_branch_protection" "repo_protection" {
   depends_on = [github_repository.repo, github_repository_collaborators.repo_collaborators]
 }
 
+resource "github_repository_environment" "env" {
+  for_each = {
+    for env in var.environments :
+    env.name => env
+  }
+
+  repository  = var.name
+  environment = each.value.name
+
+  dynamic "reviewers" {
+    for_each = each.value.reviewers != null ? [each.value.reviewers] : []
+    content {
+      teams = reviewers.value.teams
+      users = reviewers.value.users
+    }
+  }
+
+  dynamic "deployment_branch_policy" {
+    for_each = each.value.deployment_branch_policy != null ? [each.value.deployment_branch_policy] : []
+    content {
+      protected_branches     = deployment_branch_policy.value.protected_branches
+      custom_branch_policies = deployment_branch_policy.value.custom_branch_policies
+    }
+  }
+
+  depends_on = [github_repository.repo]
+}
+
 resource "github_repository_collaborators" "repo_collaborators" {
   repository = var.name
 

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -149,6 +149,32 @@ variable "allow_rebase_merge" {
   default     = true
 }
 
+variable "environments" {
+  description = "GitHub environments to create for this repository"
+  type = list(object({
+    name = string
+    reviewers = optional(object({
+      teams = optional(list(string), [])
+      users = optional(list(string), [])
+    }))
+    deployment_branch_policy = optional(object({
+      protected_branches     = optional(bool, true)
+      custom_branch_policies = optional(bool, false)
+    }))
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for env in var.environments : trimspace(env.name) != ""])
+    error_message = "All environment names must be non-empty strings."
+  }
+
+  validation {
+    condition     = length(distinct([for env in var.environments : env.name])) == length(var.environments)
+    error_message = "Environment names must be unique; duplicates would cause a for_each key collision."
+  }
+}
+
 variable "all_members_permission" {
   description = "Permission for all organization members"
   type        = string

--- a/repositories.tf
+++ b/repositories.tf
@@ -245,6 +245,7 @@ module "repo_osac_test_infra" {
     "ci/prow/temp"
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments    = [{ name = "e2e-test" }]
 }
 
 module "repo_massopencloud_templates" {


### PR DESCRIPTION
## Summary

- Add an `environments` variable to the `common_repository` module
- Create an `e2e-test` environment on `osac-test-infra`

## Why

E2e tests need secrets (cluster credentials, API tokens) from our local Vault instance on the CI runner. GitHub environments let workflows request OIDC tokens with an `environment` claim, so Vault can restrict secret access to only workflows running in `e2e-test` — rather than allowing any workflow in the org.

Other repos (fulfillment-service, osac-operator, etc.) will be onboarded in a follow-up PR once the full flow is validated on osac-test-infra.

## Test plan

- [ ] `tofu plan` shows only the new `github_repository_environment` resource for osac-test-infra
- [ ] After apply, verify the environment exists at https://github.com/osac-project/osac-test-infra/settings/environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository environment management capabilities with support for deployment protections, reviewer controls, and conditional branch policies for the e2e-test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->