### PR TITLE
Remove required status checks from repositories.tf

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -106,7 +106,7 @@ module "repo_fulfillment_service" {
     }
   ]
   required_approvals = null
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   pages = {
     build_type = "workflow"
     source = {
@@ -151,7 +151,7 @@ module "repo_cloudkit_aap" {
     }
   ]
   required_approvals = null
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
 }
 
 module "repo_cloudkit_aap_ee" {
@@ -224,8 +224,8 @@ module "repo_osac_test_infra" {
     }
   ]
   required_approvals = null
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments    = [{ name = "e2e-test" }]
+  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments       = [{ name = "e2e-test" }]
 }
 
 module "repo_massopencloud_templates" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -106,9 +106,6 @@ module "repo_fulfillment_service" {
     }
   ]
   required_approvals = null
-  required_status_checks = [
-    "ci/prow/unit"
-  ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   pages = {
     build_type = "workflow"
@@ -134,11 +131,6 @@ module "repo_cloudkit_operator" {
       permission = "admin"
     }
   ]
-
-  required_status_checks = [
-    "ci/prow/temp"
-  ]
-
   required_approvals = null
   push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
 }
@@ -159,9 +151,6 @@ module "repo_cloudkit_aap" {
     }
   ]
   required_approvals = null
-  required_status_checks = [
-    "ci/prow/temp"
-  ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
 }
 
@@ -206,12 +195,6 @@ module "repo_osac_installer" {
       permission = "admin"
     }
   ]
-
-  required_status_checks = [
-    "ci/prow/temp",
-    "ci/prow/images"
-  ]
-
   required_approvals = null
   push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
 }
@@ -241,9 +224,6 @@ module "repo_osac_test_infra" {
     }
   ]
   required_approvals = null
-  required_status_checks = [
-    "ci/prow/temp"
-  ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments    = [{ name = "e2e-test" }]
 }


### PR DESCRIPTION
Status checks are managed by Prow when the repository is managed by it, so I removed them. Removed missing (and misleading) `ci/prow/temp` check at the same time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed CI status checks from branch protection configuration across multiple repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->