### PR TITLE
OSAC-1675: Add e2e-test environment and required status checks to component repos

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -106,7 +106,12 @@ module "repo_fulfillment_service" {
     }
   ]
   required_approvals = null
-  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  required_status_checks = [
+    "ci/prow/unit",
+    "e2e-full-install / e2e"
+  ]
+  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments    = [{ name = "e2e-test" }]
   pages = {
     build_type = "workflow"
     source = {
@@ -132,7 +137,12 @@ module "repo_cloudkit_operator" {
     }
   ]
   required_approvals = null
-  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  required_status_checks = [
+    "ci/prow/temp",
+    "e2e-full-install / e2e"
+  ]
+  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments    = [{ name = "e2e-test" }]
 }
 
 module "repo_cloudkit_aap" {
@@ -151,7 +161,12 @@ module "repo_cloudkit_aap" {
     }
   ]
   required_approvals = null
-  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  required_status_checks = [
+    "ci/prow/temp",
+    "e2e-full-install / e2e"
+  ]
+  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments    = [{ name = "e2e-test" }]
 }
 
 module "repo_cloudkit_aap_ee" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -108,7 +108,7 @@ module "repo_fulfillment_service" {
   required_approvals = null
   required_status_checks = [
     "ci/prow/unit",
-    "e2e-full-install / e2e"
+    "e2e-vmaas-full-install / e2e"
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments    = [{ name = "e2e-test" }]
@@ -139,7 +139,7 @@ module "repo_cloudkit_operator" {
   required_approvals = null
   required_status_checks = [
     "ci/prow/temp",
-    "e2e-full-install / e2e"
+    "e2e-vmaas-full-install / e2e"
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments    = [{ name = "e2e-test" }]
@@ -163,7 +163,7 @@ module "repo_cloudkit_aap" {
   required_approvals = null
   required_status_checks = [
     "ci/prow/temp",
-    "e2e-full-install / e2e"
+    "e2e-vmaas-full-install / e2e"
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments    = [{ name = "e2e-test" }]
@@ -212,7 +212,7 @@ module "repo_osac_installer" {
   ]
 
   required_status_checks = [
-    "e2e-full-install / e2e"
+    "e2e-vmaas-full-install / e2e"
   ]
 
   required_approvals = null


### PR DESCRIPTION
## Summary
- Add `e2e-test` GitHub environment to fulfillment-service, osac-operator, and osac-aap (gates fork PRs from accessing self-hosted runners via environment protection rules)
- Add `required_status_checks` to enforce merge gating:
  - fulfillment-service: `ci/prow/unit`, `e2e-full-install / e2e`
  - osac-operator: `ci/prow/temp`, `e2e-full-install / e2e`
  - osac-aap: `ci/prow/temp`, `e2e-full-install / e2e`

## Test plan
- [ ] Verify Terraform plan shows expected environment and branch protection changes
- [ ] Confirm e2e-test environment appears in each repo's Settings → Environments after apply