### PR TITLE
Add members to wg-infra team

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -71,3 +71,5 @@ alosadagrande,member
 empovit,member
 ronniel1,member
 htayrie-rh,member
+masayag,member
+chenyosef,member

--- a/team-members/wg-infra.csv
+++ b/team-members/wg-infra.csv
@@ -1,3 +1,16 @@
 username,role
 eliorerz,maintainer
 omer-vishlitzky,member
+adriengentil,member
+tzvatot,member
+danmanor,member
+rccrdpccl,member
+CrystalChun,member
+masayag,member
+maorfr,member
+akshaynadkarni,member
+ygalblum,member
+oourfali,member
+ronniel1,member
+gamli75,member
+chenyosef,member

--- a/team-members/wg-infra.csv
+++ b/team-members/wg-infra.csv
@@ -14,3 +14,4 @@ oourfali,member
 ronniel1,member
 gamli75,member
 chenyosef,member
+jhernand,member


### PR DESCRIPTION
## Summary

Add 13 members to the `wg-infra` (Infrastructure working group) team:

| Name | GitHub Handle |
|------|--------------|
| Adrien Gentil | @adriengentil |
| Elad Tabak | @tzvatot |
| Dan Manor | @danmanor |
| Riccardo Piccoli | @rccrdpccl |
| Crystal Chun | @CrystalChun |
| Moti Asayag | @masayag |
| Maor Friedman | @maorfr |
| Akshay Nadkarni | @akshaynadkarni |
| Ygal Blum | @ygalblum |
| Oved Ourfali | @oourfali |
| Ronnie Lazar | @ronniel1 |
| Liat Gamliel | @gamli75 |
| Chen Yosef | @chenyosef |

Also adds `masayag` and `chenyosef` to `members.csv` as they were not yet org members.