### PR TITLE
OSAC-1675: Add e2e-full-install required check to osac-installer

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -195,8 +195,14 @@ module "repo_osac_installer" {
       permission = "admin"
     }
   ]
+
+  required_status_checks = [
+    "e2e-full-install / e2e"
+  ]
+
   required_approvals = null
   push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments       = [{ name = "e2e-test" }]
 }
 
 module "repo_enhancement_proposals" {


### PR DESCRIPTION
## Summary
- Adds `e2e-full-install / e2e` as a required status check for the osac-installer repo
- Adds the `e2e-test` GitHub environment (needed by the reusable workflow)

## Context
- osac-installer PR #357 adds the E2E full-install presubmit workflow
- osac-test-infra PR #109 (merged) fixed composite action resolution for cross-repo callers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extra merge requirements so changes must pass an end-to-end install check before approval.
  * Enabled an additional testing environment for safer validation of updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->