### PR TITLE
Add osac-ux page permission

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -81,3 +81,4 @@ Tzif-Morgen,member
 slintes,member
 udis,member
 osac-ci-bot,member
+liatb-rh,member

--- a/repositories.tf
+++ b/repositories.tf
@@ -286,6 +286,19 @@ module "repo_osac_ux" {
       permission = "push"
     }
   ]
+  users = [
+    {
+      username   = "liatb-rh"
+      permission = "maintain"
+    }
+  ]
+  pages = {
+    build_type = "workflow"
+    source = {
+      branch = "main"
+      path   = "/"
+    }
+  }
 }
 
 module "repo_host_management_openstack" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -289,7 +289,7 @@ module "repo_osac_ux" {
   users = [
     {
       username   = "liatb-rh"
-      permission = "maintain"
+      permission = "admin"
     }
   ]
   pages = {

--- a/repositories.tf
+++ b/repositories.tf
@@ -293,9 +293,9 @@ module "repo_osac_ux" {
     }
   ]
   pages = {
-    build_type = "workflow"
+    build_type = "legacy"
     source = {
-      branch = "main"
+      branch = "0.1"
       path   = "/"
     }
   }


### PR DESCRIPTION
Summary
Add liatb-rh to the organization members list
Grant liatb-rh maintain permission on the osac-ux repository
Enable GitHub Pages for osac-ux via workflow-based builds from main

Changes
members.csv

Added liatb-rh as an org member
repositories.tf (repo_osac_ux module)

Added users block granting liatb-rh the maintain role
Added pages block to enable GitHub Pages (workflow build type, sourced from main)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled GitHub Pages for the repository, using a workflow-based build from the main branch.
  * Updated repository access to grant an additional maintainer admin permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->