### PR TITLE
OSAC-2276: add cluster-tool to org-managed repository config

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -351,3 +351,21 @@ module "repo_osac_workspace" {
     }
   }
 }
+
+module "repo_cluster_tool" {
+  source      = "./modules/common_repository"
+  visibility  = "public"
+  name        = "cluster-tool"
+  description = "Instant OpenShift SNO clusters from snapshots, distributed as OCI images"
+  teams = [
+    {
+      team_id    = "fulfillment-wg"
+      permission = "push"
+    },
+    {
+      team_id    = "wg-infra"
+      permission = "admin"
+    }
+  ]
+  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+}


### PR DESCRIPTION
## Summary
- `cluster-tool` was migrated into `osac-project` but was never added to `repositories.tf`, so it currently has: no branch protection on `main`, no CI, and write/admin access granted ad-hoc to 4 individual collaborators instead of via the standard `fulfillment-wg`/`wg-infra` team model every other OSAC repo uses.
- Adds it with the `common_repository` module, modeled on `bare-metal-fulfillment-operator` (closest match — component repo, no CI/required status checks yet either).
- This will apply on merge: branch protection (1 required approval, no force-push/delete except `org-admins`), the standard label set, `has_wiki`/`has_projects` disabled, and `fulfillment-wg`/`wg-infra` team access.

Fixes https://redhat.atlassian.net/browse/OSAC-2276

## Note
The 4 existing individual direct-admin collaborators on `cluster-tool` (`larsks`, `oourfali`, `tzumainn`, `eranco74`) are intentionally left untouched by this PR — removing/replacing them with team-based access is a separate decision that needs owner sign-off, not bundled in here.

## Test plan
- [x] `tofu fmt -check -diff` passes
- [x] `pre-commit run` passes (tofu-fmt, yamllint, standard hooks)
- [ ] CI (`apply.yaml`) runs successfully on merge and confirms branch protection is applied