### PR TITLE
Add osac-metering-service repository

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -369,3 +369,27 @@ module "repo_cluster_tool" {
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
 }
+
+module "repo_osac_metering_service" {
+  source      = "./modules/common_repository"
+  visibility  = "public"
+  name        = "osac-metering-service"
+  description = "OSAC metering service"
+  teams = [
+    {
+      team_id    = "fulfillment-wg"
+      permission = "push"
+    },
+    {
+      team_id    = "observability-wg"
+      permission = "push"
+    },
+    {
+      team_id    = "wg-infra"
+      permission = "admin"
+    }
+  ]
+  required_approvals = null
+  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments       = [{ name = "e2e-test" }]
+}


### PR DESCRIPTION
## Summary
- Add `osac-metering-service` repository configuration to org-managed repos
- Teams: `fulfillment-wg` (push), `observability-wg` (push), `wg-infra` (admin)
- Full CI setup: bot merge via `openshift-merge-robot`, `e2e-test` environment, no required approvals

## Test plan
- [ ] Verify `pre-commit` CI check passes (tofu fmt, linting)
- [ ] Verify `tofu plan` shows expected repository creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the public **osac-metering-service** repository.
  * Set up an **e2e-test** environment for the repository.
* **Security / Access**
  * Configured team permissions, including push access for designated teams and admin access for infrastructure maintainers.
  * Applied repository push allowance settings to control write access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->