### PR TITLE
Add mpaulgreen to org members and fulfillment-wg

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -82,3 +82,4 @@ slintes,member
 udis,member
 osac-ci-bot,member
 liatb-rh,member
+mpaulgreen,member

--- a/team-members/fulfillment-wg.csv
+++ b/team-members/fulfillment-wg.csv
@@ -67,3 +67,4 @@ Tzif-Morgen,member
 slintes,member
 udis,member
 rgolangh,member
+mpaulgreen,member


### PR DESCRIPTION
## Summary
- Add `mpaulgreen` to `members.csv` as org member
- Add `mpaulgreen` to `team-members/fulfillment-wg.csv` as fulfillment working group member

Requested by @trewest in Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)