### PR TITLE
Add one-time TF import support for repos transferred from elsewhere

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -2,6 +2,15 @@ name: Apply configuration
 
 on:
   workflow_dispatch:
+    inputs:
+      import_address:
+        description: "One-time: Terraform resource address to import (e.g. module.repo_cluster_tool.github_repository.repo). Leave empty for a normal apply."
+        required: false
+        default: ""
+      import_id:
+        description: "One-time: import ID for the resource above (e.g. the repo name for github_repository)."
+        required: false
+        default: ""
   schedule:
     - cron: "17 */4 * * *"
   push:
@@ -42,6 +51,19 @@ jobs:
       - name: TF Validate
         run: |
           tofu validate
+      # Handles a repo that already exists on GitHub (e.g. transferred in
+      # from a personal account, like cluster-tool) but was never brought
+      # into Terraform's state -- apply would otherwise try to create it
+      # via the public_template generate API and fail with "Name already
+      # exists on this account". Manual, one-time use via workflow_dispatch
+      # inputs; a no-op (skipped entirely) for the normal scheduled/push
+      # triggers, which never set these inputs.
+      - name: TF Import (one-time, manual only)
+        if: inputs.import_address != ''
+        run: |
+          tofu import "${{ inputs.import_address }}" "${{ inputs.import_id }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: TF Apply
         run: |
           tofu apply -concise -auto-approve


### PR DESCRIPTION
## Summary

`apply.yaml`'s scheduled runs have been failing since PR #126 merged:

```
Error: POST .../repos/osac-project/public_template/generate: 422
Could not clone: Name already exists on this account
```

`cluster-tool` was migrated into `osac-project` (transferred from a personal account) before #126 added it to `repositories.tf`. The `github_repository` resource's default `use_public_template=true` means apply always tries to create the repo via the template-generate API — which fails outright for a repo that already exists and was never imported into Terraform's state.

## Fix

Add optional `import_address`/`import_id` `workflow_dispatch` inputs, consumed by a new conditional "TF Import" step that runs before apply. A no-op for the normal scheduled/push triggers (which never set these inputs), so this doesn't change day-to-day behavior — it's a one-time-use escape hatch, reusable for any future repo that gets transferred in the same way.

## Next step after merge

Run this workflow manually once with:
- `import_address`: `module.repo_cluster_tool.github_repository.repo`
- `import_id`: `cluster-tool`

That brings the existing repo into Terraform state; the next scheduled apply will then just reconcile settings (teams, push allowances, labels) instead of failing.