### PR TITLE
Add ItzikEzra-rh to org members and fulfillment-wg team

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -83,3 +83,4 @@ udis,member
 osac-ci-bot,member
 liatb-rh,member
 mpaulgreen,member
+ItzikEzra-rh,member

--- a/team-members/fulfillment-wg.csv
+++ b/team-members/fulfillment-wg.csv
@@ -68,3 +68,4 @@ slintes,member
 udis,member
 rgolangh,member
 mpaulgreen,member
+ItzikEzra-rh,member


### PR DESCRIPTION
## Summary

- Add `ItzikEzra-rh` to `members.csv` as org member
- Add `ItzikEzra-rh` to `team-members/fulfillment-wg.csv` as team member

Needed to enable Prow collaborator actions (`/lgtm`, etc.) on osac-project repos.
`ItzikEzra-rh` is already listed in OWNERS files (e.g. `osac-workspace/OWNERS`) but
Prow rejects commands because the account isn't an org collaborator yet.