### PR TITLE
OSAC-2333: Enable merge queues on core repos

### DIFF
--- a/modules/common_repository/README.md
+++ b/modules/common_repository/README.md
@@ -32,38 +32,48 @@ module "repo_docs" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [github_branch_protection.repo_protection](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
 | [github_issue_label.repo_labels](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/issue_label) | resource |
 | [github_repository.repo](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_collaborators.repo_collaborators](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_collaborators) | resource |
+| [github_repository_environment.env](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
+| [github_repository_ruleset.merge_queue](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_ruleset) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_all_members_permission"></a> [all\_members\_permission](#input\_all\_members\_permission) | Permission for all organization members | `string` | `"triage"` | no |
+| <a name="input_allow_merge_commit"></a> [allow\_merge\_commit](#input\_allow\_merge\_commit) | Allow merge commits on pull requests | `bool` | `true` | no |
+| <a name="input_allow_rebase_merge"></a> [allow\_rebase\_merge](#input\_allow\_rebase\_merge) | Allow rebase merging on pull requests | `bool` | `true` | no |
+| <a name="input_allow_squash_merge"></a> [allow\_squash\_merge](#input\_allow\_squash\_merge) | Allow squash merging on pull requests | `bool` | `true` | no |
+| <a name="input_archived"></a> [archived](#input\_archived) | Whether the repository is archived | `bool` | `false` | no |
 | <a name="input_branch_protection"></a> [branch\_protection](#input\_branch\_protection) | Configure branch protection if true | `bool` | `true` | no |
-| <a name="input_description"></a> [description](#input\_description) | Repository description | `string` | `""` | no |
+| <a name="input_description"></a> [description](#input\_description) | Repository description | `string` | n/a | yes |
+| <a name="input_environments"></a> [environments](#input\_environments) | GitHub environments to create for this repository | <pre>list(object({<br/>    name = string<br/>    reviewers = optional(object({<br/>      teams = optional(list(string), [])<br/>      users = optional(list(string), [])<br/>    }))<br/>    deployment_branch_policy = optional(object({<br/>      protected_branches     = optional(bool, true)<br/>      custom_branch_policies = optional(bool, false)<br/>    }))<br/>  }))</pre> | `[]` | no |
 | <a name="input_is_template"></a> [is\_template](#input\_is\_template) | Set this to true if this is a template repository | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | List of labels to configure on the repository | <pre>list(object({<br/>    name        = string<br/>    color       = string<br/>    description = string<br/>  }))</pre> | `null` | no |
+| <a name="input_merge_queue"></a> [merge\_queue](#input\_merge\_queue) | Enable GitHub merge queue for the default branch. When set, a repository ruleset is created that requires PRs to pass through the merge queue before merging. | <pre>object({<br/>    merge_method                   = optional(string, "SQUASH")<br/>    min_entries_to_merge           = optional(number, 1)<br/>    max_entries_to_merge           = optional(number, 5)<br/>    check_response_timeout_minutes = optional(number, 90)<br/>    grouping_strategy              = optional(string, "ALLGREEN")<br/>  })</pre> | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the repository | `string` | n/a | yes |
 | <a name="input_pages"></a> [pages](#input\_pages) | Configuration for github pages | <pre>object({<br/>    source = optional(object({<br/>      branch = string<br/>      path   = string<br/>    }))<br/>    build_type = optional(string, "legacy")<br/>    cname      = optional(string)<br/>  })</pre> | `null` | no |
+| <a name="input_push_allowances"></a> [push\_allowances](#input\_push\_allowances) | Actors allowed to push to the protected branch. When set, restricts both direct pushes and PR merges to these actors only. Actor names must begin with '/' for users or 'org-name/' for teams. | `list(string)` | `null` | no |
 | <a name="input_required_approvals"></a> [required\_approvals](#input\_required\_approvals) | Number of approvals required before merging a pull request | `number` | `1` | no |
 | <a name="input_required_status_checks"></a> [required\_status\_checks](#input\_required\_status\_checks) | A list of status checks that must pass before a PR can merge | `list(string)` | `[]` | no |
+| <a name="input_strict_status_checks"></a> [strict\_status\_checks](#input\_strict\_status\_checks) | Require the PR branch to be up to date with the base branch before merging. Disable when using merge queues, which handle this automatically. | `bool` | `true` | no |
 | <a name="input_teams"></a> [teams](#input\_teams) | Teams with access to this repository | <pre>list(object({<br/>    team_id    = string<br/>    permission = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_use_public_template"></a> [use\_public\_template](#input\_use\_public\_template) | Use the public\_template repository as the template for a new repository | `bool` | `true` | no |
 | <a name="input_users"></a> [users](#input\_users) | Users with access to this repository | <pre>list(object({<br/>    username   = string<br/>    permission = string<br/>  }))</pre> | `[]` | no |

--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -105,6 +105,33 @@ resource "github_branch_protection" "repo_protection" {
   depends_on = [github_repository.repo, github_repository_collaborators.repo_collaborators]
 }
 
+resource "github_repository_ruleset" "merge_queue" {
+  count       = var.merge_queue != null ? 1 : 0
+  name        = "merge-queue"
+  repository  = github_repository.repo.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    merge_queue {
+      merge_method                   = var.merge_queue.merge_method
+      min_entries_to_merge           = var.merge_queue.min_entries_to_merge
+      max_entries_to_merge           = var.merge_queue.max_entries_to_merge
+      check_response_timeout_minutes = var.merge_queue.check_response_timeout_minutes
+      grouping_strategy              = var.merge_queue.grouping_strategy
+    }
+  }
+
+  depends_on = [github_repository.repo]
+}
+
 resource "github_repository_environment" "env" {
   for_each = {
     for env in var.environments :

--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -105,6 +105,11 @@ resource "github_branch_protection" "repo_protection" {
   depends_on = [github_repository.repo, github_repository_collaborators.repo_collaborators]
 }
 
+data "github_team" "merge_queue_bypass" {
+  for_each = var.merge_queue != null ? toset(["wg-infra", "org-admins"]) : []
+  slug     = each.value
+}
+
 resource "github_repository_ruleset" "merge_queue" {
   count       = var.merge_queue != null ? 1 : 0
   name        = "merge-queue"
@@ -116,6 +121,15 @@ resource "github_repository_ruleset" "merge_queue" {
     ref_name {
       include = ["~DEFAULT_BRANCH"]
       exclude = []
+    }
+  }
+
+  dynamic "bypass_actors" {
+    for_each = data.github_team.merge_queue_bypass
+    content {
+      actor_id    = bypass_actors.value.id
+      actor_type  = "Team"
+      bypass_mode = "pull_request"
     }
   }
 

--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -98,7 +98,7 @@ resource "github_branch_protection" "repo_protection" {
   }
 
   required_status_checks {
-    strict   = true
+    strict   = var.strict_status_checks
     contexts = var.required_status_checks
   }
 

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -175,6 +175,18 @@ variable "environments" {
   }
 }
 
+variable "merge_queue" {
+  description = "Enable GitHub merge queue for the default branch. When set, a repository ruleset is created that requires PRs to pass through the merge queue before merging."
+  type = object({
+    merge_method                   = optional(string, "SQUASH")
+    min_entries_to_merge           = optional(number, 1)
+    max_entries_to_merge           = optional(number, 5)
+    check_response_timeout_minutes = optional(number, 90)
+    grouping_strategy              = optional(string, "ALLGREEN")
+  })
+  default = null
+}
+
 variable "all_members_permission" {
   description = "Permission for all organization members"
   type        = string

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -26,6 +26,12 @@ variable "required_status_checks" {
   default     = []
 }
 
+variable "strict_status_checks" {
+  description = "Require the PR branch to be up to date with the base branch before merging. Disable when using merge queues, which handle this automatically."
+  type        = bool
+  default     = true
+}
+
 variable "visibility" {
   description = "Repository visibility (public or private)"
   type        = string

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -191,6 +191,16 @@ variable "merge_queue" {
     grouping_strategy              = optional(string, "ALLGREEN")
   })
   default = null
+
+  validation {
+    condition     = var.merge_queue == null || contains(["MERGE", "SQUASH", "REBASE"], var.merge_queue.merge_method)
+    error_message = "merge_method must be MERGE, SQUASH, or REBASE"
+  }
+
+  validation {
+    condition     = var.merge_queue == null || contains(["ALLGREEN", "HEADGREEN"], var.merge_queue.grouping_strategy)
+    error_message = "grouping_strategy must be ALLGREEN or HEADGREEN"
+  }
 }
 
 variable "all_members_permission" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -112,6 +112,7 @@ module "repo_fulfillment_service" {
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments    = [{ name = "e2e-test" }]
+  merge_queue     = {}
   pages = {
     build_type = "workflow"
     source = {
@@ -143,6 +144,7 @@ module "repo_cloudkit_operator" {
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments    = [{ name = "e2e-test" }]
+  merge_queue     = {}
 }
 
 module "repo_cloudkit_aap" {
@@ -167,6 +169,7 @@ module "repo_cloudkit_aap" {
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments    = [{ name = "e2e-test" }]
+  merge_queue     = {}
 }
 
 module "repo_cloudkit_aap_ee" {
@@ -218,6 +221,7 @@ module "repo_osac_installer" {
   required_approvals = null
   push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments       = [{ name = "e2e-test" }]
+  merge_queue        = {}
 }
 
 module "repo_enhancement_proposals" {
@@ -247,6 +251,7 @@ module "repo_osac_test_infra" {
   required_approvals = null
   push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments       = [{ name = "e2e-test" }]
+  merge_queue        = {}
 }
 
 module "repo_massopencloud_templates" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -110,9 +110,10 @@ module "repo_fulfillment_service" {
     "ci/prow/unit",
     "e2e-vmaas-full-install / e2e"
   ]
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments    = [{ name = "e2e-test" }]
-  merge_queue     = {}
+  push_allowances      = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments         = [{ name = "e2e-test" }]
+  merge_queue          = {}
+  strict_status_checks = false
   pages = {
     build_type = "workflow"
     source = {
@@ -142,9 +143,10 @@ module "repo_cloudkit_operator" {
     "ci/prow/temp",
     "e2e-vmaas-full-install / e2e"
   ]
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments    = [{ name = "e2e-test" }]
-  merge_queue     = {}
+  push_allowances      = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments         = [{ name = "e2e-test" }]
+  merge_queue          = {}
+  strict_status_checks = false
 }
 
 module "repo_cloudkit_aap" {
@@ -167,9 +169,10 @@ module "repo_cloudkit_aap" {
     "ci/prow/temp",
     "e2e-vmaas-full-install / e2e"
   ]
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments    = [{ name = "e2e-test" }]
-  merge_queue     = {}
+  push_allowances      = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments         = [{ name = "e2e-test" }]
+  merge_queue          = {}
+  strict_status_checks = false
 }
 
 module "repo_cloudkit_aap_ee" {
@@ -219,9 +222,10 @@ module "repo_osac_installer" {
   ]
 
   required_approvals = null
-  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments       = [{ name = "e2e-test" }]
-  merge_queue        = {}
+  push_allowances      = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments         = [{ name = "e2e-test" }]
+  merge_queue          = {}
+  strict_status_checks = false
 }
 
 module "repo_enhancement_proposals" {
@@ -249,9 +253,10 @@ module "repo_osac_test_infra" {
     }
   ]
   required_approvals = null
-  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments       = [{ name = "e2e-test" }]
-  merge_queue        = {}
+  push_allowances      = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments         = [{ name = "e2e-test" }]
+  merge_queue          = {}
+  strict_status_checks = false
 }
 
 module "repo_massopencloud_templates" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -107,7 +107,6 @@ module "repo_fulfillment_service" {
   ]
   required_approvals = null
   required_status_checks = [
-    "ci/prow/unit",
     "e2e-vmaas-full-install / e2e"
   ]
   push_allowances      = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
@@ -140,7 +139,6 @@ module "repo_cloudkit_operator" {
   ]
   required_approvals = null
   required_status_checks = [
-    "ci/prow/temp",
     "e2e-vmaas-full-install / e2e"
   ]
   push_allowances      = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
@@ -166,7 +164,6 @@ module "repo_cloudkit_aap" {
   ]
   required_approvals = null
   required_status_checks = [
-    "ci/prow/temp",
     "e2e-vmaas-full-install / e2e"
   ]
   push_allowances      = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
@@ -221,7 +218,7 @@ module "repo_osac_installer" {
     "e2e-vmaas-full-install / e2e"
   ]
 
-  required_approvals = null
+  required_approvals   = null
   push_allowances      = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments         = [{ name = "e2e-test" }]
   merge_queue          = {}
@@ -252,7 +249,7 @@ module "repo_osac_test_infra" {
       permission = "admin"
     }
   ]
-  required_approvals = null
+  required_approvals   = null
   push_allowances      = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments         = [{ name = "e2e-test" }]
   merge_queue          = {}


### PR DESCRIPTION
## Summary

- Adds a `merge_queue` variable to the `common_repository` module that creates a `github_repository_ruleset` with merge queue configuration
- Enables merge queues on 5 core repos: fulfillment-service, osac-operator, osac-aap, osac-installer, osac-test-infra
- Disables `strict` status checks on those repos since the merge queue handles testing against latest main automatically

## Prerequisites — merge these first

The E2E workflows in each repo need the `merge_group` trigger before this PR is applied, otherwise the merge queue will time out (no workflow responds to merge group events) and **block all merges**.

- [ ] osac-project/osac-operator#356
- [ ] osac-project/fulfillment-service#908
- [ ] osac-project/osac-aap#419
- [ ] osac-project/osac-installer#431
- [ ] osac-project/osac-test-infra#219

**Do NOT merge this PR until all 5 above are merged.**

## Why merge queues

This is the GitHub Actions equivalent of Prow's `strict: true` — but better. Instead of requiring authors to manually rebase when main moves ahead, the merge queue automatically creates a temporary merge ref on top of latest main, runs CI against it, and merges if it passes. No author action needed.

## Merge queue defaults

| Setting | Value | Why |
|---------|-------|-----|
| `merge_method` | SQUASH | Clean linear history |
| `min_entries_to_merge` | 1 | No batching required to start |
| `max_entries_to_merge` | 5 | Allow batching when queue is busy |
| `check_response_timeout_minutes` | 90 | E2E tests take ~60-90 min |
| `grouping_strategy` | ALLGREEN | All entries in a batch must pass |

## Test plan

- [ ] `tofu plan` shows 5 new `github_repository_ruleset` resources and 5 updated `github_branch_protection` resources (strict: true → false)
- [ ] After apply, verify merge queue is available on one repo by enqueuing a test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)