### PR TITLE
NO-ISSUE: bind required checks to GitHub Actions and remove prow checks

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -128,7 +128,8 @@ resource "github_repository_ruleset" "status_checks" {
       dynamic "required_check" {
         for_each = var.required_status_checks
         content {
-          context = required_check.value
+          context        = required_check.value.context
+          integration_id = required_check.value.integration_id
         }
       }
     }

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -21,9 +21,12 @@ variable "required_approvals" {
 }
 
 variable "required_status_checks" {
-  description = "A list of status checks that must pass before a PR can merge"
-  type        = list(string)
-  default     = []
+  description = "Status checks that must pass before a PR can merge"
+  type = list(object({
+    context        = string
+    integration_id = optional(number)
+  }))
+  default = []
 }
 
 variable "visibility" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -36,7 +36,7 @@ module "repo_github_config" {
   use_public_template = false
   required_approvals  = 2
   required_status_checks = [
-    "pre-commit",
+    { context = "pre-commit", integration_id = 15368 },
   ]
 
   teams = [
@@ -107,8 +107,7 @@ module "repo_fulfillment_service" {
   ]
   required_approvals = null
   required_status_checks = [
-    "ci/prow/unit",
-    "e2e-vmaas-full-install / e2e"
+    { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments    = [{ name = "e2e-test" }]
@@ -138,8 +137,7 @@ module "repo_cloudkit_operator" {
   ]
   required_approvals = null
   required_status_checks = [
-    "ci/prow/temp",
-    "e2e-vmaas-full-install / e2e"
+    { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments    = [{ name = "e2e-test" }]
@@ -162,8 +160,7 @@ module "repo_cloudkit_aap" {
   ]
   required_approvals = null
   required_status_checks = [
-    "ci/prow/temp",
-    "e2e-vmaas-full-install / e2e"
+    { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments    = [{ name = "e2e-test" }]
@@ -212,7 +209,7 @@ module "repo_osac_installer" {
   ]
 
   required_status_checks = [
-    "e2e-vmaas-full-install / e2e"
+    { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
   ]
 
   required_approvals = null


### PR DESCRIPTION
- Change required_status_checks variable from list(string) to list(object) to support per-check integration_id
- Set integration_id = 15368 (GitHub Actions) on all required checks so rulesets can identify the source app
- Remove spurious ci/prow/unit and ci/prow/temp checks from fulfillment-service, osac-operator, and osac-aap that were auto-added to Terraform state

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Required pull request status checks now support associated integration identifiers.
  - Repository configurations use structured status check definitions for improved validation before merging.

- **Bug Fixes**
  - Improved status check recognition by associating checks with their integration, helping prevent similarly named checks from being accepted incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->