### PR TITLE
Add wg-infra as ruleset bypass actor

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -114,6 +114,15 @@ resource "github_repository_ruleset" "status_checks" {
     bypass_mode = "always"
   }
 
+  dynamic "bypass_actors" {
+    for_each = var.ruleset_bypass_team_ids
+    content {
+      actor_id    = bypass_actors.value
+      actor_type  = "Team"
+      bypass_mode = "always"
+    }
+  }
+
   conditions {
     ref_name {
       include = ["~DEFAULT_BRANCH"]

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -178,6 +178,12 @@ variable "environments" {
   }
 }
 
+variable "ruleset_bypass_team_ids" {
+  description = "Team database IDs allowed to bypass the CI status checks ruleset"
+  type        = list(number)
+  default     = []
+}
+
 variable "all_members_permission" {
   description = "Permission for all organization members"
   type        = string

--- a/repositories.tf
+++ b/repositories.tf
@@ -109,8 +109,9 @@ module "repo_fulfillment_service" {
   required_status_checks = [
     { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
   ]
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments    = [{ name = "e2e-test" }]
+  ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
+  push_allowances         = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments            = [{ name = "e2e-test" }]
   pages = {
     build_type = "workflow"
     source = {
@@ -139,8 +140,9 @@ module "repo_cloudkit_operator" {
   required_status_checks = [
     { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
   ]
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments    = [{ name = "e2e-test" }]
+  ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
+  push_allowances         = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments            = [{ name = "e2e-test" }]
 }
 
 module "repo_cloudkit_aap" {
@@ -162,8 +164,9 @@ module "repo_cloudkit_aap" {
   required_status_checks = [
     { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
   ]
-  push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments    = [{ name = "e2e-test" }]
+  ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
+  push_allowances         = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments            = [{ name = "e2e-test" }]
 }
 
 module "repo_cloudkit_aap_ee" {
@@ -212,9 +215,10 @@ module "repo_osac_installer" {
     { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
   ]
 
-  required_approvals = null
-  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments       = [{ name = "e2e-test" }]
+  required_approvals      = null
+  ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
+  push_allowances         = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments            = [{ name = "e2e-test" }]
 }
 
 module "repo_enhancement_proposals" {


### PR DESCRIPTION
## Summary

- PR #131 migrated required status checks from `github_branch_protection` to `github_repository_ruleset`, but only granted bypass to `OrganizationAdmin`
- With branch protection, `enforce_admins = false` allowed repo admins (including wg-infra) to merge when checks were pending/failing
- Rulesets don't have an equivalent implicit admin bypass — it must be explicitly granted via `bypass_actors`
- This adds `wg-infra` (team ID 17948400) as a bypass actor on repos where the team already has admin permission: fulfillment-service, osac-operator, osac-aap, osac-installer

## Changes

- `modules/common_repository/variables.tf`: add `ruleset_bypass_team_ids` variable (list of team database IDs, default `[]`)
- `modules/common_repository/main.tf`: add dynamic `bypass_actors` block for each team ID
- `repositories.tf`: pass `github_team.all["wg-infra"].id` to the 4 affected repos

## Test plan

- [ ] `tofu plan` shows 4 rulesets updated with new bypass actor, no other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for designated teams to bypass repository CI status-check rulesets.
  * Enabled this bypass for selected repositories so approved team members can proceed when required.

* **Configuration**
  * Introduced an optional setting to specify a list of team IDs allowed to bypass CI status checks.
  * Existing repository permissions and environment settings remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->