### PR TITLE
Add osac-csi-driver repository configuration

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -367,6 +367,26 @@ module "repo_cluster_tool" {
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
 }
 
+module "repo_osac_csi_driver" {
+  source      = "./modules/common_repository"
+  visibility  = "public"
+  name        = "osac-csi-driver"
+  description = "OSAC CSI driver for persistent storage"
+  teams = [
+    {
+      team_id    = "fulfillment-wg"
+      permission = "push"
+    },
+    {
+      team_id    = "wg-infra"
+      permission = "admin"
+    }
+  ]
+  required_approvals = null
+  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  environments       = [{ name = "e2e-test" }]
+}
+
 module "repo_osac_metering_service" {
   source      = "./modules/common_repository"
   visibility  = "public"


### PR DESCRIPTION
## Summary
- Add `osac-csi-driver` repository definition following the fulfillment-service pattern
- Public repo with fulfillment-wg (push) + wg-infra (admin)
- Merge via openshift-merge-robot, push allowances for wg-infra and org-admins
- e2e-test environment configured

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the public `osac-csi-driver` repository.
  * Enabled end-to-end testing for the repository.
  * Configured repository access and merge permissions for designated teams and automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->