### PR TITLE
Fix osac-ux GitHub Pages source branch

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -296,7 +296,7 @@ module "repo_osac_ux" {
   pages = {
     build_type = "legacy"
     source = {
-      branch = "0.1"
+      branch = "gh-pages"
       path   = "/"
     }
   }


### PR DESCRIPTION
Pages for `osac-ux` was configured to build from the `0.1` source branch, which is a plain code snapshot rendered via Jekyll (this is why https://osac-project.github.io/osac-ux/ shows the placeholder `public_template` README instead of the app).

The actual demo app is built and published by the `deploy-pages.yml` workflow to the `gh-pages` branch. This points Pages at `gh-pages` instead so it serves the built app.