### PR TITLE
Rename osac-metering-service repository to osac-metering

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -391,11 +391,11 @@ module "repo_osac_csi_driver" {
   environments       = [{ name = "e2e-test" }]
 }
 
-module "repo_osac_metering_service" {
+module "repo_osac_metering" {
   source      = "./modules/common_repository"
   visibility  = "public"
-  name        = "osac-metering-service"
-  description = "OSAC metering service"
+  name        = "osac-metering"
+  description = "OSAC metering service, installation chart and provider adapters"
   teams = [
     {
       team_id    = "fulfillment-wg"

--- a/repositories.tf
+++ b/repositories.tf
@@ -414,3 +414,8 @@ module "repo_osac_metering" {
   push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments       = [{ name = "e2e-test" }]
 }
+
+moved {
+  from = module.repo_osac_metering_service
+  to   = module.repo_osac_metering
+}


### PR DESCRIPTION
## Summary
- Rename repository from `osac-metering-service` to `osac-metering`
- Update description to reflect broader scope: "OSAC metering service, installation chart and provider adapters"
- Update Terraform module name from `repo_osac_metering_service` to `repo_osac_metering`

## Rationale
The repository will contain not just the metering service but also installation charts and provider adapters, so the shorter name `osac-metering` better reflects its comprehensive scope.

## Changes
- Updated `repositories.tf` with new repository name and description
- Maintained all existing team permissions and configuration settings

## Test plan
- [ ] Terraform plan shows expected repository rename
- [ ] No other references to old name remain in codebase
- [ ] Repository access and permissions remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the metering repository from `osac-metering-service` to `osac-metering`.
  * Updated the repository description to include its installation chart and provider adapters.
  * Preserved existing infrastructure state during the repository rename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->