### PR TITLE
OSAC-3364: Register new osac mono-repo in Terraform

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -121,6 +121,34 @@ module "repo_fulfillment_service" {
   }
 }
 
+module "repo_osac" {
+  source      = "./modules/common_repository"
+  visibility  = "public"
+  name        = "osac"
+  description = "OSAC mono-repo (OSAC-1732): consolidates fulfillment-service, osac-operator, osac-aap, and osac-installer"
+  teams = [
+    {
+      team_id    = "fulfillment-wg"
+      permission = "push"
+    },
+    {
+      team_id    = "wg-infra"
+      permission = "admin"
+    }
+  ]
+  required_approvals = null
+  # No required_status_checks yet -- the mono-repo's CI (OSAC-1734) doesn't exist
+  # until content is merged in. Add checks here once that CI is built, following
+  # the same pattern as repo_fulfillment_service/repo_cloudkit_operator above.
+  required_status_checks = []
+  # OSAC-1732 constraint: preserve subtree-merge history/blame going forward --
+  # squash-merging on the mono-repo would collapse that history for every
+  # commit after cutover, so it's disabled at the GitHub level, not just by convention.
+  allow_squash_merge      = false
+  ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
+  push_allowances         = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+}
+
 module "repo_cloudkit_operator" {
   source      = "./modules/common_repository"
   visibility  = "public"


### PR DESCRIPTION
## Summary
- Registers the new `osac` repo (OSAC-1732 mono-repo consolidation target) as a proper Terraform-managed resource, before it's created on GitHub
- Disables `allow_squash_merge` to enforce the migration's git-history preservation constraint at the platform level (subtree-merge history/blame must survive ongoing PRs, which squash-merging would collapse)
- Leaves `required_status_checks` empty for now — will be added once OSAC-1734 builds the mono-repo's actual CI

## Why
OSAC-1732 consolidates fulfillment-service, osac-operator, osac-aap, and osac-installer into a new `osac` repo. Creating it via the GitHub UI directly (rather than through this Terraform) would mean it's not managed the same way as every other org repo, and the scheduled `apply.yaml` (every 4h) would have no record of it.

## Test plan
- [x] `tofu fmt -check` clean
- [x] `tofu validate` passes (only pre-existing deprecation warnings unrelated to this change)
- [ ] Review team/permission choices (currently mirrors fulfillment-service/osac-operator: fulfillment-wg push, wg-infra admin)
- [ ] Merge — the actual `osac` repo gets created on the next `tofu apply`

Tracking: OSAC-1732, OSAC-3364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public `osac` repository with configured team permissions and access controls.
  * Enabled specified infrastructure-team bypass permissions and bot push allowances.
  * Configured repository merging and status-check policies to preserve existing contribution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->