### PR TITLE
OSAC-1733: Manage lock_branch in Terraform for merged component repos

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -77,6 +77,7 @@ resource "github_branch_protection" "repo_protection" {
   enforce_admins                  = false
   require_conversation_resolution = false
   require_signed_commits          = false
+  lock_branch                     = var.lock_branch
 
   force_push_bypassers = [
     "osac-project/org-admins",

--- a/modules/common_repository/variables.tf
+++ b/modules/common_repository/variables.tf
@@ -45,6 +45,12 @@ variable "branch_protection" {
   default     = true
 }
 
+variable "lock_branch" {
+  description = "Make the protected branch read-only, blocking all pushes. Intended for repositories that have been merged into another repo and are pending archival."
+  type        = bool
+  default     = false
+}
+
 variable "labels" {
   description = "List of labels to configure on the repository"
   type = list(object({

--- a/repositories.tf
+++ b/repositories.tf
@@ -95,6 +95,11 @@ module "repo_fulfillment_service" {
   visibility  = "public"
   name        = "fulfillment-service"
   description = "Cloud-in-a-box fulfillment service"
+  # Merged into osac (OSAC-1732/OSAC-1733); locked read-only pending archival
+  # (OSAC-1737). Managed here, not just via a one-off API call, since this
+  # repo's Terraform auto-apply would otherwise silently revert an
+  # out-of-band lock back to unlocked on its next run.
+  lock_branch = true
   teams = [
     {
       team_id    = "fulfillment-wg"
@@ -154,6 +159,11 @@ module "repo_cloudkit_operator" {
   visibility  = "public"
   name        = "osac-operator"
   description = "OSAC kubernetes operator"
+  # Merged into osac (OSAC-1732/OSAC-1733); locked read-only pending archival
+  # (OSAC-1737). Managed here, not just via a one-off API call, since this
+  # repo's Terraform auto-apply would otherwise silently revert an
+  # out-of-band lock back to unlocked on its next run.
+  lock_branch = true
   teams = [
     {
       team_id    = "fulfillment-wg"


### PR DESCRIPTION
## Summary

fulfillment-service and osac-operator were locked read-only via a one-off `gh api` call after being merged into osac (mono-repo consolidation, OSAC-1732/OSAC-1733), but the lock silently reverted on both repos. Root cause: this repo's Terraform has no concept of `lock_branch` at all, and `github_branch_protection` is a full-replace resource -- so the next Terraform auto-apply cycle re-applied the declared (unlocked) config and wiped out the out-of-band API change. Any manually-set `lock_branch: true` will not survive as long as Terraform doesn't know about it.

## Changes

- Added a `lock_branch` variable to `modules/common_repository` (default `false` -- no-op for every repo that doesn't set it) and wired it into the `github_branch_protection` resource.
- Set `lock_branch = true` on the `repo_fulfillment_service` and `repo_cloudkit_operator` (osac-operator) modules in `repositories.tf`, with a comment explaining why (merged into osac, pending archival per OSAC-1737).

No other repos are affected -- the variable defaults to `false`.

## Validation

- `tofu fmt -check -diff` -- clean, no formatting changes needed.
- `tofu validate` -- succeeds (only pre-existing, unrelated deprecation warnings about `has_downloads`, present before this change).
- Did not run `tofu plan`/`apply` locally against real org infrastructure -- left for this repo's normal CI/apply flow on merge.

## Test plan

- [ ] CI plan shows only the intended `lock_branch` change on fulfillment-service and osac-operator's branch protection, no other drift
- [ ] Post-merge, confirm `lock_branch` stays `true` on both repos across the next auto-apply cycle (this is the actual fix being verified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to lock protected branches and make repositories read-only.
  * Enabled branch locking for the archived `fulfillment-service` and `osac-operator` repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->