### PR TITLE
OSAC-1733: Manage osac-aap's lock_branch in Terraform

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -188,6 +188,11 @@ module "repo_cloudkit_aap" {
   visibility  = "public"
   name        = "osac-aap"
   description = "OSAC AAP configuration and playbooks"
+  # Merged into osac (OSAC-1732/OSAC-1733); locked read-only pending archival
+  # (OSAC-1737). Managed here, not just via a one-off API call, since this
+  # repo's Terraform auto-apply would otherwise silently revert an
+  # out-of-band lock back to unlocked on its next run.
+  lock_branch = true
   teams = [
     {
       team_id    = "fulfillment-wg"


### PR DESCRIPTION
## Summary

osac-aap was locked read-only via a one-off `gh api` call after being merged into `osac` (OSAC-1732/OSAC-1733) -- the same way `fulfillment-service` and `osac-operator` originally were, before #150 fixed it for them by declaring `lock_branch` in Terraform (this repo's `github_branch_protection` is a full-replace resource, so an out-of-band API toggle silently reverts on the next auto-apply cycle).

This extends that same fix to `osac-aap`, using the `lock_branch` variable #150 already added to `modules/common_repository`.

## Test plan

- [x] Matches #150's exact pattern (same comment, same variable, already validated there)
- [ ] `terraform plan` in CI should show only `lock_branch: false -> true` for `module.repo_cloudkit_aap`, no other diff