### PR TITLE
OSAC-3400: Archive dead osac-aap-ee repository

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -223,6 +223,11 @@ module "repo_cloudkit_aap_ee" {
       permission = "push"
     }
   ]
+  # Dead repo: only 2 commits (both from creation day), superseded within days by
+  # osac-aap's own execution-environment/ directory, which has been the actively
+  # maintained source of the same-named image ever since. Nothing consumes this
+  # standalone repo -- no CI publishes it, no image references it.
+  archived = true
 }
 
 module "repo_cloudkit_operator_config" {


### PR DESCRIPTION
## Summary
Sets `archived = true` on osac-aap-ee's Terraform module (`repo_cloudkit_aap_ee` in `repositories.tf`) so the next `tofu apply` archives it on GitHub.

## Why
osac-aap-ee ("OSAC execution environment for AAP") has only 2 commits, both from its creation day (2025-04-08), never touched again. osac-aap's own `execution-environment/` directory (added 3 days later, actively maintained since -- most recent commit June 2026) superseded it: its README documents `ansible-builder build --tag osac-aap-ee`, i.e. osac-aap builds the same-named image in-repo today. Nothing consumes the standalone repo -- no CI publishes it, no image references it. Its Terraform module also has minimal governance (fulfillment-wg push only, no wg-infra admin, no required checks) compared to the real component repos.

This is dead weight left over from before this org's current structure, not a mono-repo migration candidate.

## Notes
- This is the first real usage of the `archived` variable on `modules/common_repository` -- it's already plumbed through (`variables.tf` -> `main.tf`'s `github_repository.archived`), but no repo currently sets it, since the archival work for the actual mono-repo component repos (fulfillment-service/osac-operator/osac-aap/osac-installer) is still pending its own rollback window.
- Deliberately **not merging this myself** -- archiving a repo is live, hard-to-reverse GitHub state (read-only afterward; un-archiving is possible but disruptive), so this gets a human look first, same as the other repo-state-affecting PRs in this epic.

## Test plan
- [x] `tofu fmt -check -diff` clean
- [x] `tofu validate` passes (only pre-existing deprecation warnings unrelated to this change, same ones noted in PR #148)
- [ ] Human review + merge -- the repo actually gets archived on the next `tofu apply`