### PR TITLE
Require all 3 osac e2e install checks on main

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -142,10 +142,15 @@ module "repo_osac" {
     }
   ]
   required_approvals = null
-  # No required_status_checks yet -- the mono-repo's CI doesn't exist until
-  # content is merged in. Add checks here once that CI is built, following the
-  # same pattern as repo_fulfillment_service/repo_cloudkit_operator above.
-  required_status_checks = []
+  # osac's own CI (all 3 e2e install flavors) is live and has been passing on
+  # real PRs for a while now -- require all 3, not just vmaas like the
+  # pre-merge component repos below, since this is now the repo everything
+  # actually merges into.
+  required_status_checks = [
+    { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
+    { context = "e2e-bmaas-full-install / e2e", integration_id = 15368 },
+    { context = "e2e-caas-full-install / e2e", integration_id = 15368 },
+  ]
   # Preserve subtree-merge history/blame going forward -- squash-merging on the
   # mono-repo would collapse that history for every commit after cutover, so
   # it's disabled at the GitHub level, not just by convention.


### PR DESCRIPTION
## Summary
- `repo_osac`'s `required_status_checks` was left empty in Terraform with a comment explaining osac had no CI yet at the time it was created. That's stale now: osac's own e2e-vmaas/e2e-bmaas/e2e-caas full-install workflows have been running and passing on real PRs for a while.
- Live-confirmed the gap: `gh api repos/osac-project/osac/branches/main/protection` currently returns `required_status_checks: null` -- a PR can merge into `osac:main` today even with every check failing.
- Adds all 3 e2e full-install checks as required (not just vmaas like the sibling component repos), since osac is now the repo everything actually merges into, not a pre-merge staging repo.

## Verification
- `tofu fmt -check -diff`: clean.
- `tofu validate` (after `tofu init -backend=false`): valid, no new warnings (25 pre-existing unrelated deprecation warnings only).
- Actual `plan`/`apply` needs the S3 backend's CI credentials -- not runnable locally, same as every prior PR in this repo; relies on the existing apply pipeline.

## Test plan
- [ ] Confirm the ruleset applies cleanly on the next Terraform apply cycle
- [ ] Confirm `gh api repos/osac-project/osac/rulesets` shows the new `ci-status-checks` ruleset with all 3 contexts
- [ ] Confirm a PR with a failing e2e check can no longer be merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI**
  * Updated required checks for the `repo_osac` module to include all OSAC end-to-end checks: VMAAS, BMAAS, and CAAS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->