### PR TITLE
Lock bare-metal-fulfillment-operator ahead of its mono-repo merge

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -379,6 +379,10 @@ module "repo_bare_metal_operator" {
     }
   ]
   push_allowances = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
+  # Frozen ahead of OSAC-3395's merge into the osac mono-repo -- same pattern
+  # as fulfillment-service/osac-operator/osac-aap. A one-off `gh api` toggle
+  # alone reverts on the next Terraform apply cycle without this.
+  lock_branch = true
 }
 
 module "repo_osac_workspace" {


### PR DESCRIPTION
Adds `lock_branch = true` to `repo_bare_metal_operator`, matching the same pattern already applied to fulfillment-service/osac-operator/osac-aap ahead of their own OSAC-1732 merges. The branch has already been locked directly via the GitHub API as an immediate stopgap; this PR makes it durable against Terraform's own ~4h auto-apply cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Locked the repository branch to prevent further changes ahead of its planned merger into the OSAC monorepo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->