### PR TITLE
Lock osac-installer ahead of its mono-repo merge

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -267,6 +267,11 @@ module "repo_osac_installer" {
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
   push_allowances         = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments            = [{ name = "e2e-test" }]
+  # Frozen ahead of its merge into the osac mono-repo -- same pattern as
+  # fulfillment-service/osac-operator/osac-aap/bare-metal-fulfillment-operator.
+  # A one-off `gh api` toggle alone reverts on the next Terraform apply cycle
+  # without this.
+  lock_branch = true
 }
 
 module "repo_enhancement_proposals" {


### PR DESCRIPTION
Adds `lock_branch = true` to `repo_osac_installer`, matching the same pattern already applied to fulfillment-service/osac-operator/osac-aap/bare-metal-fulfillment-operator ahead of their own OSAC-1732 merges. The branch has already been locked directly via the GitHub API as an immediate stopgap; this PR makes it durable against Terraform's own ~4h auto-apply cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Locked the installer repository to its current branch before migration.
  * Added documentation clarifying the repository’s frozen status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->