### PR TITLE
OSAC-3530: Lock osac-csi-driver's branch via Terraform

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -433,6 +433,11 @@ module "repo_osac_csi_driver" {
   visibility  = "public"
   name        = "osac-csi-driver"
   description = "OSAC CSI driver for persistent storage"
+  # Merged into osac (OSAC-1732/OSAC-3530); locked read-only pending archival
+  # (OSAC-1737). Managed here, not just via a one-off API call, since this
+  # repo's Terraform auto-apply would otherwise silently revert an
+  # out-of-band lock back to unlocked on its next run.
+  lock_branch = true
   teams = [
     {
       team_id    = "fulfillment-wg"


### PR DESCRIPTION
## Summary

osac-csi-driver is merging into osac (OSAC-3530, matching the fulfillment-service/osac-operator/osac-aap precedent). Set `lock_branch = true` on its module block so the lock is durable across Terraform's auto-apply cycles, rather than a one-off API call that silently reverts on the next apply (the exact failure mode already hit and fixed for the other three components).

Also applied the same lock immediately via a direct API PUT (full GET-then-PUT preserving all other existing branch protection settings) so the repo is locked right now, not just once this PR merges.

## Validation

- `tofu fmt -check -diff` -- clean.
- `tofu validate` -- succeeds (only the same pre-existing `has_downloads` deprecation warnings noted in prior PRs).

## Test plan

- [ ] CI plan shows only the intended `lock_branch` change on osac-csi-driver's branch protection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked the repository’s branch as read-only in preparation for archival.
  * Added explanatory notes documenting the repository’s archival status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->