### PR TITLE
NO-ISSUE: Add one-time TF state rm support for unrefreshable resources

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -100,6 +100,12 @@ jobs:
             exit 1
           fi
           IFS=',' read -ra ADDRS <<< "${STATE_RM_ADDRESSES}"
+          for addr in "${ADDRS[@]}"; do
+            if [[ -z "${addr}" || "${addr}" == -* ]]; then
+              echo "::error::invalid resource address '${addr}' -- addresses must be non-empty and cannot start with '-' (tofu would parse it as an option)." >&2
+              exit 1
+            fi
+          done
           tofu state rm "${ADDRS[@]}"
         env:
           STATE_RM_ADDRESSES: ${{ inputs.state_rm_addresses }}

--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -25,7 +25,15 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # This workflow has no pull_request trigger, so github.event.pull_request.number
+  # is always null here -- the group key collapsed to just github.ref in
+  # practice, which only serializes runs against the same ref. A manual
+  # workflow_dispatch run (e.g. one-time state rm) dispatched against a
+  # non-default ref could then run concurrently with a scheduled/push apply
+  # against main, racing on the same remote state. Use a single, unqualified
+  # group so every run of this workflow -- manual or automatic, any ref --
+  # is always serialized against every other.
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:
@@ -79,12 +87,11 @@ jobs:
       - name: TF State Remove (one-time, manual only)
         if: inputs.state_rm_addresses != ''
         run: |
-          IFS=',' read -ra ADDRS <<< "${{ inputs.state_rm_addresses }}"
-          for addr in "${ADDRS[@]}"; do
-            tofu state rm "$addr"
-          done
+          IFS=',' read -ra ADDRS <<< "${STATE_RM_ADDRESSES}"
+          tofu state rm "${ADDRS[@]}"
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          STATE_RM_ADDRESSES: ${{ inputs.state_rm_addresses }}
       - name: TF Apply
         run: |
           tofu apply -concise -auto-approve

--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -11,6 +11,10 @@ on:
         description: "One-time: import ID for the resource above (e.g. the repo name for github_repository)."
         required: false
         default: ""
+      state_rm_addresses:
+        description: "One-time: comma-separated Terraform resource addresses to remove from state (e.g. for a member who left the org and whose resource can no longer be refreshed). Leave empty for a normal apply."
+        required: false
+        default: ""
   schedule:
     - cron: "17 */4 * * *"
   push:
@@ -62,6 +66,23 @@ jobs:
         if: inputs.import_address != ''
         run: |
           tofu import "${{ inputs.import_address }}" "${{ inputs.import_id }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      # Handles a resource whose live state can no longer be refreshed (e.g.
+      # a github_membership/github_team_membership for a user who left the
+      # org, which errors on read instead of just reporting "gone") --
+      # refresh failures like this abort the whole apply before anything
+      # else in the plan can land, atomically, even resources unrelated to
+      # the broken one. Manual, one-time use via workflow_dispatch input; a
+      # no-op (skipped entirely) for the normal scheduled/push triggers,
+      # which never set this input.
+      - name: TF State Remove (one-time, manual only)
+        if: inputs.state_rm_addresses != ''
+        run: |
+          IFS=',' read -ra ADDRS <<< "${{ inputs.state_rm_addresses }}"
+          for addr in "${ADDRS[@]}"; do
+            tofu state rm "$addr"
+          done
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: TF Apply

--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -35,6 +35,14 @@ concurrency:
   # is always serialized against every other.
   group: ${{ github.workflow }}
   cancel-in-progress: false
+  # Default queue behavior only keeps the single most-recently-queued run
+  # pending in a group -- an older pending run gets canceled and replaced.
+  # A manual one-time recovery run (state rm, or the exclude_addresses
+  # escape hatch) dispatched while a scheduled/push run is in progress
+  # could get silently dropped and replaced by the next automatic trigger
+  # before it ever executes. queue: max keeps every pending run queued
+  # (up to GitHub's cap of 100) instead of dropping older ones.
+  queue: max
 
 jobs:
   apply:
@@ -87,10 +95,13 @@ jobs:
       - name: TF State Remove (one-time, manual only)
         if: inputs.state_rm_addresses != ''
         run: |
+          if [[ "${STATE_RM_ADDRESSES}" == *$'\n'* ]]; then
+            echo "::error::state_rm_addresses must be comma-separated on a single line, not newline-separated." >&2
+            exit 1
+          fi
           IFS=',' read -ra ADDRS <<< "${STATE_RM_ADDRESSES}"
           tofu state rm "${ADDRS[@]}"
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           STATE_RM_ADDRESSES: ${{ inputs.state_rm_addresses }}
       - name: TF Apply
         run: |


### PR DESCRIPTION
Terraform's scheduled/push-triggered apply has been failing atomically for several runs, always on the same error:

```
Error: Error
  with github_membership.all["mvaskima"] (and jvalimak, srasanen)
  member is an invalid value for argument [{{} role}]
```

These 3 users are no longer in `members.csv`, but Terraform's remote state still tracks their `github_membership`/`github_team_membership` resources. Refreshing their live state fails (they've left the org), and that failure aborts the whole apply before anything else in the plan lands — including unrelated, already-merged changes like #161's `archived = true` settings.

This adds a one-time, manual-only `state_rm_addresses` input to the Apply workflow, mirroring the existing `import_address`/`import_id` mechanism. It's a no-op for the normal scheduled/push triggers. Once merged, I'll dispatch it once with the 6 orphaned resource addresses to clear them, then a normal apply should go through cleanly.

**Update:** addressed two rounds of CodeRabbit review (verified each finding against actual behavior rather than taking them at face value — see inline thread replies for details):
- `queue: max` on the concurrency group, so a manual one-time recovery run dispatched while a scheduled/push run is in progress can't get silently dropped and replaced before it executes (default queue behavior only keeps one pending run).
- Reject `state_rm_addresses` containing a newline before parsing (a real gap — `read` would otherwise silently truncate at the first newline).
- Simplified the concurrency group to a single `github.workflow` key (the original `github.event.pull_request.number || github.ref` was always effectively just `github.ref`, since this workflow has no `pull_request` trigger).
- Dropped `GITHUB_TOKEN` from the state-removal step — confirmed `tofu state rm` never calls the GitHub provider API, only the state backend.
- One finding ("`read` needs `-r`") didn't hold up against the actual committed code (`read -ra` already implies `-r`) — left as a reply rather than a no-op change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional manual workflow input for removing specified infrastructure state entries.
  * Added validation to reject empty, malformed, or unsafe state addresses before processing.

* **Improvements**
  * Workflow runs are now serialized globally, with pending runs retained in a queue to prevent conflicting operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->