### PR TITLE
chore(OSAC-3445): Archives the host-management-openstack repo

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -351,7 +351,10 @@ module "repo_host_management_openstack" {
   source      = "./modules/common_repository"
   visibility  = "public"
   name        = "host-management-openstack"
-  description = "OSAC Host Management Operator for OpenStack"
+  description = "[Archived] OSAC Host Management Operator for OpenStack"
+  # archived (OSAC-3445)
+  archived    = true
+  lock_branch = true
   teams = [
     {
       team_id    = "fulfillment-wg"


### PR DESCRIPTION
tofu fmt passes.
Signed-off-by: Ameya Sathe <asathe@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Repository Management**
  * Marked the repository as archived.
  * Locked the main branch to prevent unauthorized changes.
  * Allowed approved automation and administrative processes to push updates.
  * Updated the repository description to indicate its archived status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->