### PR TITLE
fix(OSAC-3445):  formatting issue with members.csv and fulfillment-wf…

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -88,6 +88,6 @@ sprizend-rh,member
 vladikr,member
 dmurugap,member
 amito,member
-jvalimak, member
-srasanen, member
-mvaskima, member
+jvalimak,member
+srasanen,member
+mvaskima,member

--- a/team-members/fulfillment-wg.csv
+++ b/team-members/fulfillment-wg.csv
@@ -73,6 +73,6 @@ sprizend-rh,member
 vladikr,member
 dmurugap,member
 amito,member
-jvalimak, member
-srasanen, member
-mvaskima, member
+jvalimak,member
+srasanen,member
+mvaskima,member


### PR DESCRIPTION
….csv

-Unblocks  application of OSAC-3445's & revert of OSAC-3534's apply using opentofu Ref: https://github.com/osac-project/github-config/pull/160

Signed-off-by: Ameya Sathe <asathe@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED