### PR TITLE
OSAC-3445: guard sub-resources for archived repos in common_repository module

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -28,7 +28,8 @@ resource "github_repository" "repo" {
 
   dynamic "pages" {
     # enable this block if `pages` is not null
-    for_each = var.pages[*]
+    # Skip pages config for archived repos (GitHub rejects it with 409)
+    for_each = var.archived ? [] : var.pages[*]
 
     content {
       cname      = pages.value.cname
@@ -51,7 +52,8 @@ resource "github_issue_label" "repo_labels" {
 
   # Generate label blocks from the value of local.values, which by default is initialized
   # by the contents of the "labels.csv" file.
-  for_each = {
+  # Skip labels for archived repos (GitHub rejects writes with 409)
+  for_each = var.archived ? {} : {
     for label in local.labels :
     label.name => label
   }
@@ -65,8 +67,9 @@ resource "github_issue_label" "repo_labels" {
 
 resource "github_branch_protection" "repo_protection" {
   # This odd looking construct lets us control the creation of the
-  # branch protection resource with a boolean variable.
-  count = var.visibility == "private" ? 0 : var.branch_protection ? 1 : 0
+  # branch protection resource with a boolean variable, and skip it
+  # entirely for archived repos (GitHub rejects writes with 409).
+  count = var.visibility == "private" ? 0 : var.archived ? 0 : var.branch_protection ? 1 : 0
 
   repository_id = var.name
   pattern       = "main"
@@ -102,7 +105,7 @@ resource "github_branch_protection" "repo_protection" {
 }
 
 resource "github_repository_ruleset" "status_checks" {
-  count = var.visibility == "private" ? 0 : var.branch_protection && length(var.required_status_checks) > 0 ? 1 : 0
+  count = var.visibility == "private" ? 0 : var.archived ? 0 : var.branch_protection && length(var.required_status_checks) > 0 ? 1 : 0
 
   name        = "ci-status-checks"
   repository  = github_repository.repo.name
@@ -149,7 +152,8 @@ resource "github_repository_ruleset" "status_checks" {
 }
 
 resource "github_repository_environment" "env" {
-  for_each = {
+  # Skip environments for archived repos (GitHub rejects writes with 409)
+  for_each = var.archived ? {} : {
     for env in var.environments :
     env.name => env
   }

--- a/removed_archived_repos.tf
+++ b/removed_archived_repos.tf
@@ -1,0 +1,101 @@
+# github_issue_label and github_repository_ruleset are safe to guard with a
+# plain count=0/empty for_each for archived repos: the underlying Terraform
+# GitHub provider (v6.12.1) already handles deleting those two resource
+# types gracefully against an archived repository (skips the delete, drops
+# it from state). github_branch_protection and github_repository_environment
+# are not -- their delete codepaths call the GitHub API directly with no
+# archived-repo handling, so flipping their count/for_each to zero for an
+# archived repo (in modules/common_repository/main.tf) would make Terraform
+# attempt to destroy the existing resource with unverified behavior against
+# an archived repo. `removed` blocks tell Terraform to stop managing these
+# specific already-existing instances without ever issuing a delete.
+#
+# See the review discussion on osac-project/github-config#165 for the full
+# analysis (CodeRabbit + follow-up).
+#
+# One block is required per already-archived repo, since `removed` targets
+# a concrete resource address rather than a dynamic set.
+
+removed {
+  from = module.repo_fulfillment_service.github_branch_protection.repo_protection
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_fulfillment_service.github_repository_environment.env
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_cloudkit_operator.github_branch_protection.repo_protection
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_cloudkit_operator.github_repository_environment.env
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_cloudkit_aap.github_branch_protection.repo_protection
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_cloudkit_aap.github_repository_environment.env
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_osac_installer.github_branch_protection.repo_protection
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_osac_installer.github_repository_environment.env
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_osac_csi_driver.github_branch_protection.repo_protection
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_osac_csi_driver.github_repository_environment.env
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_host_management_openstack.github_branch_protection.repo_protection
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.repo_bare_metal_operator.github_branch_protection.repo_protection
+  lifecycle {
+    destroy = false
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `var.archived` guards to `modules/common_repository/main.tf` for `pages`, `github_issue_label`, `github_branch_protection`, `github_repository_ruleset.status_checks`, and `github_repository_environment` — GitHub returns 409 on writes to these sub-resources for archived repos.
- `github_repository.repo` already set `archived = var.archived`; the module never skipped the dependent sub-resources, which is the root cause of the `tofu apply` GitHub Action failures below.

## Related PRs whose `tofu apply` failed because of this gap
| PR | Jira | Description |
|----|------|-------------|
| [#158](https://github.com/osac-project/github-config/pull/158) | OSAC-3534 | Set `archived=true` for repos merged into osac mono-repo (original introduction of the gap) |
| [#161](https://github.com/osac-project/github-config/pull/161) | OSAC-3534 | Revert of the revert — re-applied `archived=true` without the module fix |
| [#163](https://github.com/osac-project/github-config/pull/163) | OSAC-3445 | Archived `host-management-openstack` — hit the same 409 failures |

(PR #159, the interim revert of #158, is not affected since it undid the archival rather than triggering the bug.)

## What gets unblocked
Once merged, the pending `tofu apply` drift for the repos archived in #158/#161/#163 (`fulfillment-service`, `osac-operator`, `osac-aap`, `osac-installer`, `bare-metal-fulfillment-operator`, `osac-csi-driver`, `host-management-openstack`) will apply cleanly instead of failing with 409 errors on branch protection, rulesets, labels, pages, and environments.

## Test plan
- [x] `tofu init -backend=false && tofu validate` — passes (only pre-existing deprecation warnings)
- [x] CodeRabbit CLI review (`--agent`, committed vs `upstream/main`) — 0 findings
- [ ] `tofu apply` succeeds in CI for the previously-failing archived repos

Assisted-by: Claude Code (claude-sonnet-5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archived repositories are now excluded from unsupported GitHub configuration updates, preventing 409 errors.
  * Existing settings for archived repositories are preserved without triggering destructive changes.
  * Active repositories continue to receive GitHub Pages, labels, branch protection, status-check rulesets, and environment settings as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->