### PR TITLE
Update osac repo's required status check for CaaS Netris rename

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -147,7 +147,7 @@ module "repo_osac" {
   required_status_checks = [
     { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
     { context = "e2e-bmaas-full-install / e2e", integration_id = 15368 },
-    { context = "e2e-caas-full-install / e2e", integration_id = 15368 },
+    { context = "e2e-caas-netris-full-install / e2e", integration_id = 15368 },
   ]
   # Preserve subtree-merge history/blame going forward -- squash-merging on the
   # mono-repo would collapse that history for every commit after cutover, so


### PR DESCRIPTION
## Why

osac-project/osac#110 (merged 2026-08-05) deleted `e2e-caas-full-install.yml` and replaced it with `e2e-caas-netris-full-install.yml`, but this repo's branch protection for `osac` still requires the old check name (`e2e-caas-full-install / e2e`). That check will never report again, which would permanently block every future PR on `osac`'s ruleset (short of an admin bypass).

## What

Points the required status check at the new workflow's gating job (`e2e-caas-netris-full-install / e2e`) — same `<workflow-basename> / e2e` pattern already used for the vmaas/bmaas entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated required validation checks to use the correct end-to-end installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->