### PR TITLE
Revert "Update osac repo's required status check for CaaS Netris rename"

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -147,7 +147,7 @@ module "repo_osac" {
   required_status_checks = [
     { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
     { context = "e2e-bmaas-full-install / e2e", integration_id = 15368 },
-    { context = "e2e-caas-netris-full-install / e2e", integration_id = 15368 },
+    { context = "e2e-caas-full-install / e2e", integration_id = 15368 },
   ]
   # Preserve subtree-merge history/blame going forward -- squash-merging on the
   # mono-repo would collapse that history for every commit after cutover, so


### PR DESCRIPTION
Netris Job is still not stable and blocking PRs reverting osac-project/github-config#166


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated required status checks for `repo_osac` to use the current end-to-end installation check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->