### PR TITLE
NO-ISSUE: Add failure isolation to Apply configuration workflow

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -104,11 +104,17 @@ jobs:
             exit 1
           fi
           IFS=',' read -ra ADDRS <<< "${STATE_RM_ADDRESSES}"
-          for addr in "${ADDRS[@]}"; do
+          for i in "${!ADDRS[@]}"; do
+            addr="${ADDRS[$i]}"
+            # Trim surrounding whitespace, since "addr1, addr2" (space after
+            # the comma) is the natural way to type this list by hand.
+            addr="${addr#"${addr%%[![:space:]]*}"}"
+            addr="${addr%"${addr##*[![:space:]]}"}"
             if [[ -z "${addr}" || "${addr}" == -* ]]; then
               echo "::error::invalid resource address '${addr}' -- addresses must be non-empty and cannot start with '-' (tofu would parse it as an option)." >&2
               exit 1
             fi
+            ADDRS[$i]="${addr}"
           done
           tofu state rm "${ADDRS[@]}"
         env:

--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -15,6 +15,10 @@ on:
         description: "One-time: comma-separated Terraform resource addresses to remove from state (e.g. for a member who left the org and whose resource can no longer be refreshed). Leave empty for a normal apply."
         required: false
         default: ""
+      exclude_addresses:
+        description: "One-time: comma-separated Terraform resource addresses to exclude from this apply (e.g. a resource that's known-broken and blocking every other pending change atomically, while a permanent fix is prepared). Leave empty for a normal apply."
+        required: false
+        default: ""
   schedule:
     - cron: "17 */4 * * *"
   push:
@@ -109,8 +113,80 @@ jobs:
           tofu state rm "${ADDRS[@]}"
         env:
           STATE_RM_ADDRESSES: ${{ inputs.state_rm_addresses }}
+      # A one-time, manual escape hatch: a single broken/unrefreshable
+      # resource aborts this entire apply atomically (see #162, #165 for two
+      # real instances), silently blocking every other repo's pending
+      # changes until someone happens to notice. -exclude lets a maintainer
+      # immediately unblock everyone else while the permanent fix for the
+      # broken resource is prepared, without giving up dependency-complete
+      # single-pass apply for the normal case. A no-op for the normal
+      # scheduled/push triggers, which never set this input.
+      #
+      # A permanent per-module `-target` loop was considered and rejected:
+      # several modules share cross-module resources (e.g.
+      # github_team.all["wg-infra"], referenced by ruleset_bypass_team_ids
+      # in multiple repo modules), so looping per module would re-plan/
+      # re-apply those shared resources on every iteration that references
+      # them -- wasteful, and it gives up Terraform's normal whole-graph
+      # dependency ordering for no real isolation benefit in the common
+      # case where nothing is broken. -exclude only sacrifices ordering
+      # guarantees for the specific resources a maintainer has deliberately
+      # chosen to skip, one time -- note that -exclude also skips anything
+      # that depends on the excluded resource, so it unblocks everything
+      # *not* downstream of the broken one, not literally everything else.
       - name: TF Apply
+        id: tofu_apply
         run: |
-          tofu apply -concise -auto-approve
+          EXCLUDE_ARGS=()
+          if [[ -n "${EXCLUDE_ADDRESSES}" ]]; then
+            if [[ "${EXCLUDE_ADDRESSES}" == *$'\n'* ]]; then
+              echo "::error::exclude_addresses must be comma-separated on a single line, not newline-separated." >&2
+              exit 1
+            fi
+            IFS=',' read -ra ADDRS <<< "${EXCLUDE_ADDRESSES}"
+            for addr in "${ADDRS[@]}"; do
+              # Trim surrounding whitespace, since "addr1, addr2" (space after
+              # the comma) is the natural way to type this list by hand.
+              addr="${addr#"${addr%%[![:space:]]*}"}"
+              addr="${addr%"${addr##*[![:space:]]}"}"
+              if [[ -z "${addr}" || "${addr}" == -* ]]; then
+                echo "::error::invalid resource address '${addr}' -- addresses must be non-empty and cannot start with '-' (tofu would parse it as an option)." >&2
+                exit 1
+              fi
+              EXCLUDE_ARGS+=("-exclude=${addr}")
+            done
+          fi
+          tofu apply -concise -auto-approve "${EXCLUDE_ARGS[@]}"
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          EXCLUDE_ADDRESSES: ${{ inputs.exclude_addresses }}
+      # tofu apply isn't atomic and doesn't roll back changes already
+      # applied earlier in the same run if a later resource fails -- but a
+      # hard error on one resource does still stop the run before anything
+      # after it in the plan is attempted, which is what actually blocked
+      # every other repo's pending changes here (the host-management-
+      # openstack archived-repo bug, #165) with no signal beyond a red
+      # Actions run. File or update a tracking issue so a stuck apply is
+      # never silent again. Scoped to TF Apply's own outcome specifically
+      # (not the broader failure() built-in, which would also match an
+      # earlier checkout/init/validate/import failure).
+      - name: File an issue on apply failure
+        if: ${{ failure() && steps.tofu_apply.outcome == 'failure' }}
+        env:
+          # Only gh + GITHUB_TOKEN are needed here -- explicitly clear the
+          # job-level AWS backend credentials rather than let this step
+          # inherit them unnecessarily.
+          AWS_ACCESS_KEY_ID: ""
+          AWS_SECRET_ACCESS_KEY: ""
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create apply-failure --repo "${{ github.repository }}" \
+            --color d73a4a --description "tofu apply is failing" --force
+          EXISTING=$(gh issue list --repo "${{ github.repository }}" --label apply-failure --state open --json number --jq '.[0].number')
+          BODY="\`tofu apply\` failed at ${RUN_URL}. This blocks *every* repo's pending Terraform changes until resolved -- see the run log for which resource caused it."
+          if [[ -n "${EXISTING}" ]]; then
+            gh issue comment "${EXISTING}" --repo "${{ github.repository }}" --body "${BODY}"
+          else
+            gh issue create --repo "${{ github.repository }}" --title "Apply configuration is failing" --label apply-failure --body "${BODY}"
+          fi


### PR DESCRIPTION
## Why

A single broken/unrefreshable resource aborts the entire `tofu apply` atomically, blocking every other repo's pending Terraform changes with no signal beyond a red Actions run. This has happened twice independently: the `host-management-openstack` archived-repo bug (#165) and orphaned `github_membership` entries for users who left the org (#162). The CaaS-Netris required-check rename sat un-applied for hours because of the former — only discovered by chance while investigating an unrelated CI queue backlog.

## What

Two complementary changes, chosen after evaluating (and rejecting) a permanent per-module `-target` loop — see tradeoff writeup below:

1. **File/comment on a tracking issue when `tofu apply` fails**, so a stuck apply is never silent again. Uses the same GitHub App token already generated for `tofu` itself (`issues: write` is already granted on this app installation) — no new secrets. Reuses an existing open `apply-failure`-labeled issue via comment rather than spamming a new one on every scheduled retry.
2. **One-time, manual `exclude_addresses` workflow_dispatch input**, mirroring #162's `state_rm_addresses` pattern, threaded into `tofu apply -exclude=...`. Lets a maintainer immediately unblock every other repo's pending changes when one specific resource is known-broken, while a permanent fix is prepared — without giving up single-pass, dependency-complete apply for the normal (nothing-broken) case.

## Why not a permanent per-module `-target` loop

Considered and rejected. Checked this repo's actual module structure first rather than assuming it's free:

- Several modules share cross-module resources — e.g. `github_team.all["wg-infra"]` is referenced via `ruleset_bypass_team_ids` in 5+ separate repo modules. A per-module loop would redundantly re-plan/re-apply that shared resource on every iteration that references it.
- `-target` mode explicitly gives up Terraform's whole-graph dependency ordering (per OpenTofu's own docs: "not recommended for routine use"). For the common case where nothing is broken, this trades away a real safety property for zero benefit.
- ~30+ separate `tofu apply -target=...` invocations instead of one materially increases apply time and provider API calls every single run, not just during an incident.
- Implementing correct continue-on-error semantics across the loop (GH Actions `run:` steps default to `bash -eo pipefail`) adds real complexity for a benefit (failure isolation) the `exclude_addresses` escape hatch already covers on-demand, at the moment it's actually needed.

## Test plan

- [x] `yamllint --strict -c .yamllint.yaml .github/workflows/apply.yaml` — passes
- [x] Extracted both new bash blocks and ran `shellcheck` — clean, no warnings
- [ ] Exercise `exclude_addresses` for real the next time a resource is known-broken (can't simulate a live `tofu apply` failure safely without real state access)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional inputs to remove specified resources from state during manual apply runs.
  * Added optional resource exclusions for manual apply runs, with validation and whitespace handling.
  * Manual workflow runs are now processed in order without discarding queued runs.
  * Failed apply runs now create or update a labeled issue with a direct link to the failed run.
  * AWS credentials are cleared when an apply fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->