### PR TITLE
Mirror required status checks into classic branch protection for tide

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -101,6 +101,28 @@ resource "github_branch_protection" "repo_protection" {
     }
   }
 
+  # Prow's tide only derives its own merge-gating required contexts from
+  # this (classic) branch-protection API -- it has no knowledge of
+  # repository rulesets at all (confirmed against tide's actual source,
+  # pkg/config/tide.go: FromBranchProtection reads bp.RequiredStatusChecks,
+  # which maps to this exact API, not rulesets). Since every repo here
+  # already relies on org-wide tide.context_options.from-branch-protection
+  # (the global default in openshift/release, no per-repo override), tide
+  # was merging PRs on labels alone the moment none of these contexts were
+  # ever mirrored here -- confirmed on a real PR (#85) that merged with all
+  # 3 required e2e checks still 50+ minutes from completing. Mirror the
+  # same contexts already enforced by the ruleset below so tide actually
+  # waits, without introducing a second, independently-maintained list --
+  # both come from the same var.required_status_checks.
+  dynamic "required_status_checks" {
+    for_each = length(var.required_status_checks) > 0 ? [1] : []
+
+    content {
+      strict   = true
+      contexts = [for check in var.required_status_checks : check.context]
+    }
+  }
+
   depends_on = [github_repository.repo, github_repository_collaborators.repo_collaborators]
 }
 

--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -101,19 +101,12 @@ resource "github_branch_protection" "repo_protection" {
     }
   }
 
-  # Prow's tide only derives its own merge-gating required contexts from
-  # this (classic) branch-protection API -- it has no knowledge of
-  # repository rulesets at all (confirmed against tide's actual source,
-  # pkg/config/tide.go: FromBranchProtection reads bp.RequiredStatusChecks,
-  # which maps to this exact API, not rulesets). Since every repo here
-  # already relies on org-wide tide.context_options.from-branch-protection
-  # (the global default in openshift/release, no per-repo override), tide
-  # was merging PRs on labels alone the moment none of these contexts were
-  # ever mirrored here -- confirmed on a real PR (#85) that merged with all
-  # 3 required e2e checks still 50+ minutes from completing. Mirror the
-  # same contexts already enforced by the ruleset below so tide actually
-  # waits, without introducing a second, independently-maintained list --
-  # both come from the same var.required_status_checks.
+  # Prow's tide derives its merge-gating required contexts only from this
+  # (classic) branch-protection API, not from rulesets (pkg/config/tide.go:
+  # FromBranchProtection reads bp.RequiredStatusChecks). This field was
+  # never set here, so tide merged on labels alone, blind to e2e status.
+  # Mirror the same contexts already enforced by the ruleset below, from
+  # the same var.required_status_checks, so there's one list to maintain.
   dynamic "required_status_checks" {
     for_each = length(var.required_status_checks) > 0 ? [1] : []
 


### PR DESCRIPTION
## Why

Prow's `tide` merges PRs based purely on labels here, blind to e2e status entirely -- confirmed on a real merge, not theorized.

**`osac-project/osac`#85** was merged by `openshift-merge-bot[bot]` at `21:11:20Z`, while all three of its *required* e2e checks (`e2e-bmaas-full-install / e2e`, `e2e-vmaas-full-install / e2e`, `e2e-caas-full-install / e2e`) were still running -- they didn't complete until `22:03:04Z`, `22:26:11Z`, and `22:33:41Z` respectively (52-82 minutes *after* the merge). All three eventually passed, but only well after the fact.

Root cause, confirmed at the source level, not guessed: `osac`'s Prow config relies on the org-wide `tide.context_options.from-branch-protection` default (no per-repo override in `openshift/release`) to derive which contexts tide should wait for. Checked tide's actual implementation (`kubernetes-sigs/prow`, `pkg/config/tide.go`):

```go
if options.FromBranchProtection != nil && *options.FromBranchProtection {
    bp, err := c.GetBranchProtection(org, repo, branch, presubmits)
    ...
    if bp.Protect != nil && *bp.Protect && bp.RequiredStatusChecks != nil {
        required.Insert(bp.RequiredStatusChecks.Contexts...)
    }
}
```

`bp.RequiredStatusChecks` maps directly to GitHub's **classic** branch-protection API -- there's no repository-rulesets-aware code path anywhere in this function. And classic branch protection on `osac/main` has never had `required_status_checks` set -- only the newer ruleset (`github_repository_ruleset.status_checks`) does:

```
$ gh api repos/osac-project/osac/branches/main/protection --jq '.required_status_checks'
null
```

So tide's computed required-context set for every repo managed by this Terraform has always been empty. It merges the instant `approved`+`jira/valid-reference`+`lgtm` labels are present, with no blocking labels -- it was never actually waiting for e2e, on any PR, ever. Most PRs happen to look compliant only because reviewers naturally wait to see CI pass before approving, as a matter of habit, not because anything enforces it.

(Checked 5 other recently-merged PRs for comparison: 4 were fully compliant, e2e finishing well before merge. The one other match, `#170`, turned out to be an unrelated, legitimate mechanism -- merged directly by a human `wg-infra` team member via the UI, using their own explicitly-configured ruleset bypass rights, not tide.)

## What

Mirror the same contexts already enforced by `github_repository_ruleset.status_checks` into `github_branch_protection.repo_protection`'s own `required_status_checks` block -- both generated from the same `var.required_status_checks` input, so there's one list to maintain per repo, not two independently-drifting ones. `strict = true` matches the ruleset's own `strict_required_status_checks_policy = true`.

## Why this over the alternative (editing openshift/release directly)

Considered setting `context-options.required-contexts` explicitly in `osac`'s own `_prowconfig.yaml` in `openshift/release` instead. Went with this approach because:
- It requires no PR against an external repo tide's config actually needs a human with `openshift/release` merge rights to review.
- It keeps a single source of truth (`var.required_status_checks` in `repositories.tf`) instead of three (the workflow file names, the ruleset, and now a separate Prow config entry) -- exactly the kind of drift that caused the CaaS-Netris rename to silently break tide's gating in the first place, if it had needed a third place to update.
- It fixes this for every repo managed by this module that sets `required_status_checks`, not just `osac` -- `osac-installer` and `fulfillment-service` have the same latent gap today, just not yet observed on a real PR.

## Blast radius

Only affects repos where `required_status_checks` is non-empty in `repositories.tf` (currently `osac`, `osac-installer`, `fulfillment-service`). No change for repos without required checks configured (the `dynamic` block stays empty for them, matching the existing ruleset's own conditional).

**Behavioral change to expect:** any PR currently sitting with `approved`+`lgtm` but incomplete e2e will stop being tide-mergeable until those checks actually finish. This was already GitHub's own ruleset-enforced behavior for a human clicking "Merge" in the UI -- this closes the gap specifically for tide's automated merges, which is where it was actually being skipped.

## Test plan

- [x] `tofu init -backend=false && tofu validate` -- passes (same pre-existing deprecation warnings as always)
- [ ] Confirm via `gh api repos/osac-project/osac/branches/main/protection --jq '.required_status_checks'` that it reflects the three e2e contexts once applied
- [ ] Confirm on the next real PR that tide waits for all three e2e checks before merging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable required status checks for protected branches.
  * Supports strict status-check enforcement based on configured settings.
  * Automatically applies the configured status-check contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->