### PR TITLE
Grant wg-infra org-level self-hosted runner management

### DIFF
--- a/organization.tf
+++ b/organization.tf
@@ -9,3 +9,21 @@ resource "github_organization_settings" "osac-project" {
   members_can_create_public_repositories  = false
   members_can_create_repositories         = false
 }
+
+# Lets wg-infra manage self-hosted runners/runner groups at the org level
+# (register/remove runners, create runner groups, control repo access to
+# them) without granting full org-owner access. base_role defaults to
+# "none", so this role carries only the permission listed below.
+resource "github_organization_role" "runner_manager" {
+  name        = "runner-manager"
+  description = "Manage organization self-hosted runners and runner groups"
+
+  permissions = [
+    "manage_organization_runners",
+  ]
+}
+
+resource "github_organization_role_team" "runner_manager_wg_infra" {
+  role_id   = github_organization_role.runner_manager.role_id
+  team_slug = github_team.all["wg-infra"].slug
+}


### PR DESCRIPTION
## What

Adds a custom organization role granting the "Manage organization runners and runner groups" permission (create/manage org-level self-hosted runners and runner groups, without full org-owner access), bound to `wg-infra`.

```hcl
resource "github_organization_role" "runner_manager" {
  name        = "runner-manager"
  description = "Manage organization self-hosted runners and runner groups"
  permissions = ["manage_organization_runners"]
}

resource "github_organization_role_team" "runner_manager_wg_infra" {
  role_id   = github_organization_role.runner_manager.role_id
  team_slug = github_team.all["wg-infra"].slug
}
```

`base_role` defaults to `none`, so this role carries exactly the one permission above -- nothing else.

## Why

`wg-infra` manages the org's self-hosted runner fleet but currently has no clean, non-owner way to register/remove runners or manage runner groups through the GitHub UI/API. Custom Organization Roles (GitHub Enterprise Cloud) exist for exactly this.

## On the permission string

`manage_organization_runners` is not confirmed against a live `GET /orgs/{org}/organization-fine-grained-permissions` call (would need `admin:org`, not currently available). It's sourced from:
- GitHub's [Actions Fine Grained Permissions changelog](https://github.blog/changelog/2024-03-06-actions-fine-grained-permissions/) confirming this permission category shipped for custom org roles, described in the UI as "Manage organization runners and runner groups".
- A real, actively-maintained third-party tool ([`joshjohanning/bulk-github-org-settings-sync-action`](https://github.com/joshjohanning/bulk-github-org-settings-sync-action/blob/main/sample-configuration/custom-org-roles.yml)) that ships this exact string in a sample config for a "CI/CD Manager" role described as managing "Actions settings and self-hosted runners", alongside the sibling `manage_organization_actions_settings`. Its code passes `permissions` straight through to the API with no client-side validation, so this reflects a real API value, not a guess by that project's author.
- It matches the naming convention already visible in GitHub's own docs for related roles (`read_organization_custom_org_role` / `write_organization_custom_org_role`).

If the string is wrong, `tofu apply` will fail with a clear invalid-permission error from GitHub's API rather than silently doing the wrong thing, and we'll take the real value from the error/logs.

## Separately: GitHub App installation permission

Applying this also requires the `github-config` GitHub App's own installation to have **"Custom organization roles: Write"** -- confirmed via the same third-party tool's own required-permissions list. I could not check our app's current installation permissions (needs org-owner access I don't have). If the apply run fails with a 403/permission-denied on the `github_organization_role` create (as opposed to an invalid-permission-string error), that's the likely cause, and would need an org owner to add that permission to the app's installation directly -- not fixable via Terraform or a personal login.

## Validation

- `tofu init -backend=false && tofu validate`: passes (pre-existing unrelated deprecation warnings only)
- `tofu fmt`: clean
- `pre-commit run --files organization.tf`: passes

NO-ISSUE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added organization-level permissions for managing runners.
  - Granted runner management access to the infrastructure team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->