### PR TITLE
Add one-time manual diagnostic to list org fine-grained permissions

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -20,7 +20,7 @@ on:
         required: false
         default: ""
       list_org_fine_grained_permissions:
-        description: "One-time: set to 'true' to print the org's live custom-role fine-grained permission names to the job summary (e.g. to find the exact permission string for a github_organization_role, since GitHub's docs only show UI labels, not identifiers). Read-only, runs before TF Apply. Leave empty for a normal apply."
+        description: "One-time: set to 'true' to print the org's live custom-role fine-grained permission names to the job summary (e.g. to find the exact permission string for a github_organization_role, since GitHub's docs only show UI labels, not identifiers). Read-only: skips TF Import/TF State Remove/TF Apply for this run. Leave empty for a normal apply."
         required: false
         default: ""
   schedule:
@@ -80,6 +80,11 @@ jobs:
       - name: List org fine-grained permissions (one-time, manual only)
         if: inputs.list_org_fine_grained_permissions == 'true'
         env:
+          # Only gh + GITHUB_TOKEN are needed here -- explicitly clear the
+          # job-level AWS backend credentials rather than let this step
+          # inherit them unnecessarily.
+          AWS_ACCESS_KEY_ID: ""
+          AWS_SECRET_ACCESS_KEY: ""
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           gh api "orgs/${{ github.repository_owner }}/organization-fine-grained-permissions" > /tmp/org-perms.json
@@ -108,7 +113,7 @@ jobs:
       # inputs; a no-op (skipped entirely) for the normal scheduled/push
       # triggers, which never set these inputs.
       - name: TF Import (one-time, manual only)
-        if: inputs.import_address != ''
+        if: inputs.import_address != '' && inputs.list_org_fine_grained_permissions != 'true'
         run: |
           tofu import "${{ inputs.import_address }}" "${{ inputs.import_id }}"
         env:
@@ -122,7 +127,7 @@ jobs:
       # no-op (skipped entirely) for the normal scheduled/push triggers,
       # which never set this input.
       - name: TF State Remove (one-time, manual only)
-        if: inputs.state_rm_addresses != ''
+        if: inputs.state_rm_addresses != '' && inputs.list_org_fine_grained_permissions != 'true'
         run: |
           if [[ "${STATE_RM_ADDRESSES}" == *$'\n'* ]]; then
             echo "::error::state_rm_addresses must be comma-separated on a single line, not newline-separated." >&2
@@ -167,6 +172,7 @@ jobs:
       # *not* downstream of the broken one, not literally everything else.
       - name: TF Apply
         id: tofu_apply
+        if: inputs.list_org_fine_grained_permissions != 'true'
         run: |
           EXCLUDE_ARGS=()
           if [[ -n "${EXCLUDE_ADDRESSES}" ]]; then

--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -19,6 +19,10 @@ on:
         description: "One-time: comma-separated Terraform resource addresses to exclude from this apply (e.g. a resource that's known-broken and blocking every other pending change atomically, while a permanent fix is prepared). Leave empty for a normal apply."
         required: false
         default: ""
+      list_org_fine_grained_permissions:
+        description: "One-time: set to 'true' to print the org's live custom-role fine-grained permission names to the job summary (e.g. to find the exact permission string for a github_organization_role, since GitHub's docs only show UI labels, not identifiers). Read-only, runs before TF Apply. Leave empty for a normal apply."
+        required: false
+        default: ""
   schedule:
     - cron: "17 */4 * * *"
   push:
@@ -65,6 +69,27 @@ jobs:
           client-id: Iv23lipEOAvwk5QqNUie
           private-key: ${{ secrets.CONFIG_APP_SECRET }}
           owner: ${{ github.repository_owner }}
+      # Read-only lookup, no Terraform involved -- GitHub's docs only show
+      # the UI label for custom-org-role permissions (e.g. "Manage
+      # organization runners and runner groups"), not the identifier string
+      # a github_organization_role resource actually needs. This queries
+      # the live API via the same app token Terraform itself uses, instead
+      # of guessing. Manual, one-time use via workflow_dispatch input; a
+      # no-op (skipped entirely) for the normal scheduled/push triggers,
+      # which never set this input.
+      - name: List org fine-grained permissions (one-time, manual only)
+        if: inputs.list_org_fine_grained_permissions == 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh api "orgs/${{ github.repository_owner }}/organization-fine-grained-permissions" > /tmp/org-perms.json
+          {
+            echo "### All org fine-grained permissions"
+            jq -r '.[] | "- `\(.name)`: \(.description)"' /tmp/org-perms.json
+            echo
+            echo "### Runner-related"
+            jq -r '.[] | select(.description | test("runner"; "i")) | "- `\(.name)`: \(.description)"' /tmp/org-perms.json
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@v2
         with:


### PR DESCRIPTION
## What

PR #173 shipped `github_organization_role.runner_manager` with `permissions = ["manage_organization_runners"]`. The apply that merge triggered failed:

```
Error: error creating organization role (osac-project/runner-manager): POST https://api.github.com/orgs/osac-project/organization-roles: 422 Invalid permission: `manage_organization_runners`. []
```

(Full failure, auto-filed per the existing failure-isolation mechanism: #174.) This confirms the app *does* have write access to custom org roles -- it's purely a wrong permission-string problem, not an installation-permission blocker. GitHub's docs only ever show the UI label ("Manage organization runners and runner groups"), never the identifier string, so guessing again isn't worth it when the live API can just answer directly.

Adds a manual-only, read-only `workflow_dispatch` step (`list_org_fine_grained_permissions`) that calls `GET /orgs/{org}/organization-fine-grained-permissions` using the same app token Terraform already uses, and writes the full permission list (plus a runner-filtered subset) to the job summary. No Terraform involved, no state touched. A no-op for the normal scheduled/push triggers.

## Plan once merged

1. Dispatch this workflow once with `list_org_fine_grained_permissions=true` **and** `exclude_addresses=github_organization_role.runner_manager,github_organization_role_team.runner_manager_wg_infra` (the existing escape hatch from #169) in the same run, so the other 4 pending unrelated changes blocked since the #173 apply failure aren't held up further while this gets sorted.
2. Read the real permission string from the job summary.
3. Fix `organization.tf` with the correct string in a fast-follow PR, and remove this diagnostic step in the same PR (one-time use, no ongoing utility once the string is known -- unlike `exclude_addresses`/`state_rm_addresses`/`import_address`, which are reusable escape hatches).
4. Verify live that the role and team binding actually get created, and close #174.

NO-ISSUE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional manual workflow setting to list organization fine-grained permissions.
  * Displays all available permissions, including runner-related entries, in the job summary when enabled.
  * Standard scheduled, push, and manual runs remain unchanged unless the setting is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->