### PR TITLE
Tee the org-permissions diagnostic to the job log

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -94,7 +94,7 @@ jobs:
             echo
             echo "### Runner-related"
             jq -r '.[] | select(.description | test("runner"; "i")) | "- `\(.name)`: \(.description)"' /tmp/org-perms.json
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@v2
         with:


### PR DESCRIPTION
## What

#175's diagnostic dispatch (run [31149352826](https://github.com/osac-project/github-config/actions/runs/31149352826)) worked correctly -- but its output only landed in \`\$GITHUB_STEP_SUMMARY\`, which turns out not to be retrievable via the REST or GraphQL API at all, only rendered in the Actions web UI. Tees the same output to stdout too, so it's readable from \`gh run view --log\` / the normal job log.

## Context

Separately: a second, non-diagnostic dispatch of \`apply.yaml\` in the meantime hit the same known #173 permission-string failure again and re-filed the apply-failure issue as #176 (after #174 was closed). That's expected -- \`organization.tf\` still has the broken \`manage_organization_runners\` string until this diagnostic actually confirms the right one. Once this merges I'll dispatch once more with both \`list_org_fine_grained_permissions=true\` and \`exclude_addresses=github_organization_role.runner_manager,github_organization_role_team.runner_manager_wg_infra\` together, to get the real string without re-triggering the failure.

NO-ISSUE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow reporting so permission results are displayed both in live logs and in the summarized workflow output.
  * No changes to the application’s functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->