### PR TITLE
Fix org role permission string, remove the now-unneeded diagnostic

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -19,10 +19,6 @@ on:
         description: "One-time: comma-separated Terraform resource addresses to exclude from this apply (e.g. a resource that's known-broken and blocking every other pending change atomically, while a permanent fix is prepared). Leave empty for a normal apply."
         required: false
         default: ""
-      list_org_fine_grained_permissions:
-        description: "One-time: set to 'true' to print the org's live custom-role fine-grained permission names to the job summary (e.g. to find the exact permission string for a github_organization_role, since GitHub's docs only show UI labels, not identifiers). Read-only: skips TF Import/TF State Remove/TF Apply for this run. Leave empty for a normal apply."
-        required: false
-        default: ""
   schedule:
     - cron: "17 */4 * * *"
   push:
@@ -69,32 +65,6 @@ jobs:
           client-id: Iv23lipEOAvwk5QqNUie
           private-key: ${{ secrets.CONFIG_APP_SECRET }}
           owner: ${{ github.repository_owner }}
-      # Read-only lookup, no Terraform involved -- GitHub's docs only show
-      # the UI label for custom-org-role permissions (e.g. "Manage
-      # organization runners and runner groups"), not the identifier string
-      # a github_organization_role resource actually needs. This queries
-      # the live API via the same app token Terraform itself uses, instead
-      # of guessing. Manual, one-time use via workflow_dispatch input; a
-      # no-op (skipped entirely) for the normal scheduled/push triggers,
-      # which never set this input.
-      - name: List org fine-grained permissions (one-time, manual only)
-        if: inputs.list_org_fine_grained_permissions == 'true'
-        env:
-          # Only gh + GITHUB_TOKEN are needed here -- explicitly clear the
-          # job-level AWS backend credentials rather than let this step
-          # inherit them unnecessarily.
-          AWS_ACCESS_KEY_ID: ""
-          AWS_SECRET_ACCESS_KEY: ""
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          gh api "orgs/${{ github.repository_owner }}/organization-fine-grained-permissions" > /tmp/org-perms.json
-          {
-            echo "### All org fine-grained permissions"
-            jq -r '.[] | "- `\(.name)`: \(.description)"' /tmp/org-perms.json
-            echo
-            echo "### Runner-related"
-            jq -r '.[] | select(.description | test("runner"; "i")) | "- `\(.name)`: \(.description)"' /tmp/org-perms.json
-          } | tee -a "$GITHUB_STEP_SUMMARY"
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@v2
         with:
@@ -113,7 +83,7 @@ jobs:
       # inputs; a no-op (skipped entirely) for the normal scheduled/push
       # triggers, which never set these inputs.
       - name: TF Import (one-time, manual only)
-        if: inputs.import_address != '' && inputs.list_org_fine_grained_permissions != 'true'
+        if: inputs.import_address != ''
         run: |
           tofu import "${{ inputs.import_address }}" "${{ inputs.import_id }}"
         env:
@@ -127,7 +97,7 @@ jobs:
       # no-op (skipped entirely) for the normal scheduled/push triggers,
       # which never set this input.
       - name: TF State Remove (one-time, manual only)
-        if: inputs.state_rm_addresses != '' && inputs.list_org_fine_grained_permissions != 'true'
+        if: inputs.state_rm_addresses != ''
         run: |
           if [[ "${STATE_RM_ADDRESSES}" == *$'\n'* ]]; then
             echo "::error::state_rm_addresses must be comma-separated on a single line, not newline-separated." >&2
@@ -172,7 +142,6 @@ jobs:
       # *not* downstream of the broken one, not literally everything else.
       - name: TF Apply
         id: tofu_apply
-        if: inputs.list_org_fine_grained_permissions != 'true'
         run: |
           EXCLUDE_ARGS=()
           if [[ -n "${EXCLUDE_ADDRESSES}" ]]; then

--- a/organization.tf
+++ b/organization.tf
@@ -19,7 +19,7 @@ resource "github_organization_role" "runner_manager" {
   description = "Manage organization self-hosted runners and runner groups"
 
   permissions = [
-    "manage_organization_runners",
+    "write_organization_runners_and_runner_groups",
   ]
 }
 


### PR DESCRIPTION
## What

Fixes the root cause of #174/#176: `manage_organization_runners` (from #173) was rejected by the live API with `422 Invalid permission`. A one-time diagnostic dispatch of #175/#177 confirmed the real identifier directly from `GET /orgs/osac-project/organization-fine-grained-permissions` (run [31149779707](https://github.com/osac-project/github-config/actions/runs/31149779707)):

```
write_organization_runners_and_runner_groups: Manage organization runners and runner groups
```

Updates `organization.tf`'s `permissions` list accordingly.

Also removes the diagnostic step and its `list_org_fine_grained_permissions` input from `apply.yaml` entirely -- it did its one job. Unlike `exclude_addresses`/`state_rm_addresses`/`import_address`, which are reusable escape hatches worth keeping, this had no future utility once the string was known. `apply.yaml` is now byte-identical to its pre-#175 state (verified via `git diff` against that commit).

## Validation

- `tofu init -backend=false && tofu validate`: passes (pre-existing unrelated deprecation warnings only)
- `tofu fmt`: clean
- `yamllint --strict` + `pre-commit`: clean

## Once merged

I'll dispatch a normal apply (or wait for the next scheduled run) to confirm the role and team binding actually get created live, then close #174/#176.

NO-ISSUE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated organization runner management permissions to support writing organization runners and runner groups.

* **Changes**
  * Simplified the manual apply workflow by removing the fine-grained permissions lookup option and related conditional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->