### PR TITLE
OSAC-3734: fix label-gate required check name

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -149,7 +149,7 @@ module "repo_osac" {
     { context = "e2e-caas-full-install / e2e", integration_id = 15368 },
     # Reads Prow-set labels (lgtm, approved, jira/valid-reference) and converts
     # them to a status check the merge queue can gate on.
-    { context = "label-gate / check-labels", integration_id = 15368 },
+    { context = "check-labels", integration_id = 15368 },
   ]
   # Preserve subtree-merge history/blame going forward -- squash-merging on the
   # mono-repo would collapse that history for every commit after cutover, so


### PR DESCRIPTION
## Summary

Fix the required status check context for the label-gate workflow: `check-labels` instead of `label-gate / check-labels`.

The `<workflow> / <job>` naming format only applies to reusable workflow calls. Single-workflow jobs report just the job name. The current config causes the check to show as "Expected — Waiting for status to be reported" even though the workflow passes.

One-line change: `repositories.tf` line 152.

## Test plan

- [ ] After tofu apply: `check-labels` shows as satisfied (not "Expected") on PRs where label-gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the required status check name to ensure repository validation uses the correct check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->