### PR TITLE
OSAC-3734: update required checks to E2E gate job names

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -144,9 +144,9 @@ module "repo_osac" {
   # check for the merge queue.
   required_approvals = null
   required_status_checks = [
-    { context = "e2e-vmaas-full-install / e2e", integration_id = 15368 },
-    { context = "e2e-bmaas-full-install / e2e", integration_id = 15368 },
-    { context = "e2e-caas-full-install / e2e", integration_id = 15368 },
+    { context = "e2e-vmaas-gate", integration_id = 15368 },
+    { context = "e2e-bmaas-gate", integration_id = 15368 },
+    { context = "e2e-caas-gate", integration_id = 15368 },
     # Reads Prow-set labels (lgtm, approved, jira/valid-reference) and converts
     # them to a status check the merge queue can gate on.
     { context = "label-gate / check-labels", integration_id = 15368 },


### PR DESCRIPTION
## Summary

Update required status checks from reusable workflow job names to gate job names:

| Before | After |
|--------|-------|
| `e2e-vmaas-full-install / e2e` | `e2e-vmaas-gate` |
| `e2e-bmaas-full-install / e2e` | `e2e-bmaas-gate` |
| `e2e-caas-full-install / e2e` | `e2e-caas-gate` |

### Why

The reusable workflow check (`e2e-vmaas-full-install / e2e`) only exists when E2E actually runs. Docs-only PRs skip E2E, so the check is never reported — merge queue blocks forever with "Expected — Waiting for status."

Gate jobs (osac#222) always run and report a result: pass for docs-only PRs (no E2E needed), pass/fail for code PRs (reflects E2E result).

### Merge order

1. **osac#222** — rename gate jobs (must exist before this PR changes required checks)
2. **This PR** — update required check names to match

## Test plan

- [ ] After both PRs merge: docs-only PRs show `e2e-vmaas-gate` as passed, can enter merge queue
- [ ] Code PRs: gate jobs reflect actual E2E result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated required status checks for VMAAS, BMAAS, and CAAS to use the appropriate end-to-end validation gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->