### PR TITLE
OSAC-3734: remove classic branch protection required_status_checks

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -101,20 +101,6 @@ resource "github_branch_protection" "repo_protection" {
     }
   }
 
-  # Prow's tide derives its merge-gating required contexts only from this
-  # (classic) branch-protection API, not from rulesets (pkg/config/tide.go:
-  # FromBranchProtection reads bp.RequiredStatusChecks). This field was
-  # never set here, so tide merged on labels alone, blind to e2e status.
-  # Mirror the same contexts already enforced by the ruleset below, from
-  # the same var.required_status_checks, so there's one list to maintain.
-  dynamic "required_status_checks" {
-    for_each = length(var.required_status_checks) > 0 ? [1] : []
-
-    content {
-      strict   = true
-      contexts = [for check in var.required_status_checks : check.context]
-    }
-  }
 
   depends_on = [github_repository.repo, github_repository_collaborators.repo_collaborators]
 }


### PR DESCRIPTION
## Summary

Remove the `required_status_checks` block from classic branch protection. It was added in c17e367 to make Tide respect E2E checks — Tide only reads classic branch protection, not rulesets.

With merge queue replacing Tide, this block is unnecessary and actively harmful: its hardcoded `strict = true` conflicts with merge queue, causing PRs to be ejected from the queue after all checks pass.

From GitHub docs:
> "You should not combine the merge queue with the 'Require branches to be up to date before merging' option in branch protection rules, as this can lead to unexpected behavior."

### Evidence

PRs 180, 212, 182 were repeatedly ejected from the merge queue despite all checks passing. Every ejection correlated with main moving (a bypassed merge of PR 172 at 18:14 caused ejection of all three at 19:15).

### What still enforces checks

The repository ruleset (`ci-status-checks`) has the same required checks with `strict = false` — merge queue handles freshness by testing against latest main.

## Test plan

- [ ] After tofu apply: `gh api repos/osac-project/osac/branches/main/protection/required_status_checks` returns `null`
- [ ] PRs in merge queue are NOT ejected when main moves (queue re-tests instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated branch protection behavior so required status checks are managed through repository rulesets.
  * Removed status-check configuration from classic branch protection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->