### PR TITLE
fix: allow merge queue bot to push to protected branches

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -119,6 +119,17 @@ resource "github_repository_ruleset" "status_checks" {
     bypass_mode = "always"
   }
 
+  # GitHub Merge Queue app — must bypass the ruleset to push rebased
+  # commits to the protected branch after queue checks pass.
+  dynamic "bypass_actors" {
+    for_each = var.merge_queue != null ? [1] : []
+    content {
+      actor_id    = 262318
+      actor_type  = "Integration"
+      bypass_mode = "always"
+    }
+  }
+
   dynamic "bypass_actors" {
     for_each = var.ruleset_bypass_team_ids
     content {
@@ -136,6 +147,11 @@ resource "github_repository_ruleset" "status_checks" {
   }
 
   rules {
+    # When merge queue is enabled, block direct pushes via the ruleset
+    # instead of classic branch protection's restrict_pushes — the merge
+    # queue bot cannot be added to branch protection but can bypass rulesets.
+    update = var.merge_queue != null ? true : false
+
     required_status_checks {
       # When merge queue is enabled, strict is unnecessary — the queue tests
       # each PR against latest main before merging.

--- a/repositories.tf
+++ b/repositories.tf
@@ -156,12 +156,15 @@ module "repo_osac" {
   # it's disabled at the GitHub level, not just by convention.
   allow_squash_merge      = false
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
-  # openshift-merge-robot removed: Tide no longer merges; merge queue handles it.
-  push_allowances = ["osac-project/wg-infra", "osac-project/org-admins"]
+  # push_allowances removed: classic branch protection's "Restrict who can push"
+  # overrides the merge queue bot's implicit push access and cannot include it
+  # (the bot is an internal GitHub app with no discoverable slug). The ruleset's
+  # merge_queue rule prevents unauthorized merges; force_push_bypassers (above)
+  # controls force pushes.
 
   merge_queue = {
     merge_method                      = "REBASE"
-    max_entries_to_build              = 3
+    max_entries_to_build              = 4
     max_entries_to_merge              = 5
     min_entries_to_merge              = 1
     min_entries_to_merge_wait_minutes = 5


### PR DESCRIPTION
## Summary

- Add GitHub Merge Queue bot (Integration 262318) as a conditional ruleset bypass actor for repos with merge queue enabled
- Add `update = true` rule to the ruleset so direct pushes to main are blocked via the ruleset (only bypass actors can push directly)
- Remove `push_allowances` from osac repo — classic branch protection's "Restrict who can push" overrides the merge queue bot's implicit push access, and the bot cannot be added to it (internal GitHub app with no discoverable slug)
- Increase `max_entries_to_build` from 3 to 4 (12 self-hosted runners for queue, leaves 28 for PR checks)

## Context

The merge queue was dequeuing PRs with all checks passing because the bot couldn't push the rebased result to main — `branch_protection_failure`. Root cause: classic branch protection's `restrict_pushes` listed specific teams, which overrides the default list that includes the merge queue bot. Moving push restrictions to the ruleset (via `update = true`) lets the merge queue bot bypass them as a ruleset bypass actor.

## Test plan

- [ ] Verify merge queue successfully merges a PR after queue checks pass
- [ ] Verify direct `git push origin main` is rejected for non-bypass actors
- [ ] Verify wg-infra and org-admins can still push directly when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added merge queue support to repository rules when merge queue configuration is enabled.
  * Increased the maximum number of entries built concurrently in the merge queue from three to four.
* **Bug Fixes**
  * Direct pushes are now blocked when merge queue protection is active, ensuring changes follow the required merge workflow.
  * Removed legacy branch-protection exceptions that could bypass the standard review and merge process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->