### PR TITLE
feat: add merge queue to osac-test-infra, grant wg-infra bypass on github-config

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -147,10 +147,16 @@ resource "github_repository_ruleset" "status_checks" {
   }
 
   rules {
-    # When merge queue is enabled, block direct pushes via the ruleset
-    # instead of classic branch protection's restrict_pushes — the merge
-    # queue bot cannot be added to branch protection but can bypass rulesets.
-    update = var.merge_queue != null ? true : false
+    # When merge queue is enabled, require a PR for all changes. This
+    # blocks direct `git push` to main (unlike `update = true` which also
+    # breaks auto-merge evaluation). Native review count is 0 because
+    # approval is handled by Prow labels + check-labels gate.
+    dynamic "pull_request" {
+      for_each = var.merge_queue != null ? [1] : []
+      content {
+        required_approving_review_count = 0
+      }
+    }
 
     required_status_checks {
       # When merge queue is enabled, strict is unnecessary — the queue tests

--- a/repositories.tf
+++ b/repositories.tf
@@ -38,11 +38,16 @@ module "repo_github_config" {
   required_status_checks = [
     { context = "pre-commit", integration_id = 15368 },
   ]
+  ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
 
   teams = [
     {
       team_id    = "fulfillment-wg"
       permission = "push"
+    },
+    {
+      team_id    = "wg-infra"
+      permission = "admin"
     }
   ]
 }
@@ -307,8 +312,26 @@ module "repo_osac_test_infra" {
     }
   ]
   required_approvals = null
-  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments       = [{ name = "e2e-test" }]
+  required_status_checks = [
+    { context = "e2e-vmaas-gate", integration_id = 15368 },
+    { context = "e2e-bmaas-gate", integration_id = 15368 },
+    { context = "e2e-caas-gate", integration_id = 15368 },
+    { context = "check-labels", integration_id = 15368 },
+  ]
+  ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
+  # push_allowances removed: classic branch protection's "Restrict who can
+  # push" blocks the merge queue bot. Ruleset update rule handles this instead.
+  environments = [{ name = "e2e-test" }]
+
+  merge_queue = {
+    merge_method                      = "REBASE"
+    max_entries_to_build              = 4
+    max_entries_to_merge              = 5
+    min_entries_to_merge              = 1
+    min_entries_to_merge_wait_minutes = 5
+    check_response_timeout_minutes    = 120
+    grouping_strategy                 = "ALLGREEN"
+  }
 }
 
 module "repo_massopencloud_templates" {


### PR DESCRIPTION
## Summary

**osac-test-infra:**
- Add merge queue with same settings as osac (REBASE, ALLGREEN, batch 4)
- Add required status checks (e2e gates + check-labels)
- Add wg-infra as ruleset bypass team
- Remove push_allowances (conflicts with merge queue bot)

**github-config:**
- Add wg-infra team with admin permission
- Add wg-infra as ruleset bypass team (can force merge)

## Dependencies

Depends on osac-test-infra PR adding label-gate, e2e gate jobs, and auto-queue workflows.

## Test plan

- [ ] Verify osac-test-infra PRs go through merge queue after workflow PR lands
- [ ] Verify wg-infra members can bypass and merge directly on github-config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added merge queue support to repository rulesets when configured.
  * Increased merge queue capacity and added required status checks.
  * Added administrative access and ruleset bypass permissions for the GitHub configuration repository.

* **Bug Fixes**
  * Direct pushes are now blocked when merge queue enforcement is enabled.
  * Replaced legacy push allowance settings with ruleset-based controls for test infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->