### PR TITLE
fix: remove pull_request ruleset rule, restore push_allowances

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -147,17 +147,6 @@ resource "github_repository_ruleset" "status_checks" {
   }
 
   rules {
-    # When merge queue is enabled, require a PR for all changes. This
-    # blocks direct `git push` to main (unlike `update = true` which also
-    # breaks auto-merge evaluation). Native review count is 0 because
-    # approval is handled by Prow labels + check-labels gate.
-    dynamic "pull_request" {
-      for_each = var.merge_queue != null ? [1] : []
-      content {
-        required_approving_review_count = 0
-      }
-    }
-
     required_status_checks {
       # When merge queue is enabled, strict is unnecessary — the queue tests
       # each PR against latest main before merging.

--- a/repositories.tf
+++ b/repositories.tf
@@ -161,11 +161,7 @@ module "repo_osac" {
   # it's disabled at the GitHub level, not just by convention.
   allow_squash_merge      = false
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
-  # push_allowances removed: classic branch protection's "Restrict who can push"
-  # overrides the merge queue bot's implicit push access and cannot include it
-  # (the bot is an internal GitHub app with no discoverable slug). The ruleset's
-  # merge_queue rule prevents unauthorized merges; force_push_bypassers (above)
-  # controls force pushes.
+  push_allowances         = ["osac-project/wg-infra", "osac-project/org-admins"]
 
   merge_queue = {
     merge_method                      = "REBASE"
@@ -319,9 +315,8 @@ module "repo_osac_test_infra" {
     { context = "check-labels", integration_id = 15368 },
   ]
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
-  # push_allowances removed: classic branch protection's "Restrict who can
-  # push" blocks the merge queue bot. Ruleset update rule handles this instead.
-  environments = [{ name = "e2e-test" }]
+  push_allowances         = ["osac-project/wg-infra", "osac-project/org-admins"]
+  environments            = [{ name = "e2e-test" }]
 
   merge_queue = {
     merge_method                      = "REBASE"


### PR DESCRIPTION
## Summary

- Remove `pull_request` rule from ruleset — it blocks PRs when CodeRabbit has outstanding CHANGES_REQUESTED, even with `required_approving_review_count=0`
- Restore `push_allowances` for osac and osac-test-infra — classic branch protection `restrict_pushes` blocks direct pushes without interfering with the merge queue bot (confirmed working)

## Context

The `pull_request` ruleset rule enforces native GitHub review requirements. Since OSAC uses Prow labels (`lgtm`/`approved`) via the `check-labels` gate instead of native reviews, this rule is incompatible — CodeRabbit's reviews block merging.

Direct push protection via classic branch protection `restrict_pushes` works with the merge queue because GitHub auto-allows the merge queue bot when `restrict_pushes` is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access and Permissions**
  * Updated repository push permissions to allow designated infrastructure and administrator teams.
  * Adjusted merge-queue repository rules to remove the native pull request requirement.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->