### PR TITLE
fix: re-enable pull_request rule, remove push_allowances

### DIFF
--- a/modules/common_repository/main.tf
+++ b/modules/common_repository/main.tf
@@ -147,6 +147,15 @@ resource "github_repository_ruleset" "status_checks" {
   }
 
   rules {
+    # Block direct pushes — require a PR. CHANGES_REQUESTED reviews are
+    # auto-dismissed by the auto-queue workflow so they don't block merging.
+    dynamic "pull_request" {
+      for_each = var.merge_queue != null ? [1] : []
+      content {
+        required_approving_review_count = 0
+      }
+    }
+
     required_status_checks {
       # When merge queue is enabled, strict is unnecessary — the queue tests
       # each PR against latest main before merging.

--- a/repositories.tf
+++ b/repositories.tf
@@ -161,7 +161,6 @@ module "repo_osac" {
   # it's disabled at the GitHub level, not just by convention.
   allow_squash_merge      = false
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
-  push_allowances         = ["osac-project/wg-infra", "osac-project/org-admins"]
 
   merge_queue = {
     merge_method                      = "REBASE"
@@ -315,7 +314,6 @@ module "repo_osac_test_infra" {
     { context = "check-labels", integration_id = 15368 },
   ]
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
-  push_allowances         = ["osac-project/wg-infra", "osac-project/org-admins"]
   environments            = [{ name = "e2e-test" }]
 
   merge_queue = {


### PR DESCRIPTION
## Summary

- Re-add `pull_request` ruleset rule (blocks direct pushes, requires PRs)
- Remove `push_allowances` from osac and osac-test-infra (classic branch protection `restrict_pushes` conflicts with merge queue bot)
- Safe now because osac-project/osac#279 auto-dismisses CHANGES_REQUESTED reviews

## Dependencies

- osac-project/osac#279 (merged) — auto-dismiss CHANGES_REQUESTED reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added merge queue compatibility for repository status checks.
  * Pull requests processed through the merge queue now follow an explicit zero-approval review rule.

* **Changes**
  * Updated repository access settings by removing legacy push-allowance restrictions from selected repositories.
  * All other repository configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->