### PR TITLE
chore: delete osac-metering repository

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -476,32 +476,3 @@ module "repo_osac_csi_driver" {
   push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
   environments       = [{ name = "e2e-test" }]
 }
-
-module "repo_osac_metering" {
-  source      = "./modules/common_repository"
-  visibility  = "public"
-  name        = "osac-metering"
-  description = "OSAC metering service, installation chart and provider adapters"
-  teams = [
-    {
-      team_id    = "fulfillment-wg"
-      permission = "push"
-    },
-    {
-      team_id    = "observability-wg"
-      permission = "push"
-    },
-    {
-      team_id    = "wg-infra"
-      permission = "admin"
-    }
-  ]
-  required_approvals = null
-  push_allowances    = ["/openshift-merge-robot", "osac-project/wg-infra", "osac-project/org-admins"]
-  environments       = [{ name = "e2e-test" }]
-}
-
-moved {
-  from = module.repo_osac_metering_service
-  to   = module.repo_osac_metering
-}


### PR DESCRIPTION
## Summary

Removes the `osac-metering` Terraform module so the next `tofu apply` deletes the `osac-metering` GitHub repository.

Rationale: work has been consolidated into the `osac` mono-repo, and `osac-metering` never received any commits — it's an empty repository and pure dead weight.

## Changes

- Delete the `module "repo_osac_metering"` block from `repositories.tf`.
- Delete the now-orphaned `moved` block that pointed `repo_osac_metering_service` → `repo_osac_metering` (leaving it would reference a non-existent module and fail `tofu validate`).

## ⚠️ Deletion is permanent

`modules/common_repository` does not set `archive_on_destroy`, so removing the module makes Terraform/OpenTofu **permanently delete** the repository rather than archive it. This is intentional here because the repo is empty. (This differs from previously consolidated repos such as `fulfillment-service` and `osac-operator`, which were *archived* because they contained history worth preserving.)

Reviewers: please confirm the repo is genuinely empty before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)