### PR TITLE
NO-ISSUE: Require osac pre-commit, unit, and integration checks

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -155,6 +155,17 @@ module "repo_osac" {
     # Reads Prow-set labels (lgtm, approved, jira/valid-reference) and converts
     # them to a status check the merge queue can gate on.
     { context = "check-labels", integration_id = 15368 },
+    # Names match GitHub Actions job `name:` (or job id if unnamed). Job-level
+    # `if:` skips report success, so docs-only PRs are not blocked.
+    { context = "pre-commit", integration_id = 15368 },
+    { context = "Run unit tests", integration_id = 15368 },
+    { context = "Run unit tests (osac-metering)", integration_id = 15368 },
+    { context = "Run unit tests (osac-metering/adapters)", integration_id = 15368 },
+    { context = "Run unit tests (osac-metering/schema)", integration_id = 15368 },
+    { context = "Run integration test (fulfillment-service)", integration_id = 15368 },
+    { context = "Run integration test (osac-operator)", integration_id = 15368 },
+    { context = "Run integration test (osac-aap)", integration_id = 15368 },
+    { context = "Run integration test (osac-installer)", integration_id = 15368 },
   ]
   # Preserve subtree-merge history/blame going forward -- squash-merging on the
   # mono-repo would collapse that history for every commit after cutover, so


### PR DESCRIPTION
## Summary
- Add existing osac GitHub Actions jobs (`pre-commit`, unit tests, integration tests) to `repo_osac` `required_status_checks` so failures block merge.
- No new gate jobs. Job-level `if:` skips already report success, so docs-only PRs stay mergeable.

## Test plan
- [ ] `tofu plan` shows only `repo_osac` required-check additions
- [ ] After apply, a code PR that fails unit/integration/pre-commit cannot merge
- [ ] Docs-only PR still mergeable (skipped jobs count as success)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded required status checks for repository changes.
  * Added validation for pre-commit checks, unit tests, and integration tests across key service and installer components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->