### PR TITLE
Revert "NO-ISSUE: Require osac pre-commit, unit, and integration checks"

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -155,17 +155,6 @@ module "repo_osac" {
     # Reads Prow-set labels (lgtm, approved, jira/valid-reference) and converts
     # them to a status check the merge queue can gate on.
     { context = "check-labels", integration_id = 15368 },
-    # Names match GitHub Actions job `name:` (or job id if unnamed). Job-level
-    # `if:` skips report success, so docs-only PRs are not blocked.
-    { context = "pre-commit", integration_id = 15368 },
-    { context = "Run unit tests", integration_id = 15368 },
-    { context = "Run unit tests (osac-metering)", integration_id = 15368 },
-    { context = "Run unit tests (osac-metering/adapters)", integration_id = 15368 },
-    { context = "Run unit tests (osac-metering/schema)", integration_id = 15368 },
-    { context = "Run integration test (fulfillment-service)", integration_id = 15368 },
-    { context = "Run integration test (osac-operator)", integration_id = 15368 },
-    { context = "Run integration test (osac-aap)", integration_id = 15368 },
-    { context = "Run integration test (osac-installer)", integration_id = 15368 },
   ]
   # Preserve subtree-merge history/blame going forward -- squash-merging on the
   # mono-repo would collapse that history for every commit after cutover, so


### PR DESCRIPTION
Reverts osac-project/github-config#191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository merge requirements by removing several pre-commit, unit-test, and integration-test status checks.
  * Retained end-to-end validation and label checks as required gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->