### PR TITLE
feat: require osac-test-infra pre-commit check

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -308,6 +308,10 @@ module "repo_osac_test_infra" {
     { context = "e2e-bmaas-gate", integration_id = 15368 },
     { context = "e2e-caas-gate", integration_id = 15368 },
     { context = "check-labels", integration_id = 15368 },
+    # Job name in osac-test-infra/.github/workflows/pre-commit.yaml.
+    # That workflow must listen to merge_group or the queue waits
+    # check_response_timeout_minutes for a check that never reports.
+    { context = "pre-commit", integration_id = 15368 },
   ]
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
   environments            = [{ name = "e2e-test" }]


### PR DESCRIPTION
## Summary
- Add `pre-commit` to `repo_osac_test_infra` required status checks (job name in osac-test-infra `pre-commit.yaml`).
- osac-test-infra#401 already added `merge_group` for that workflow. Do not apply this ruleset before that is on `main` (it is).
- Does not change osac monorepo required checks.

## Test plan
- [ ] tofu plan shows only `repo_osac_test_infra` required-check addition
- [ ] After apply, enqueue a code PR on osac-test-infra
- [ ] Merge-group SHA shows `pre-commit` success/failure quickly (not pending until timeout)
- [ ] Failed pre-commit blocks merge; E2E gates still run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `repo_osac` merge queue to use squash merges.
  * Removed the restriction prohibiting squash merges.
  * Updated merge queue requirements to include the `pre-commit` status check.
  * Added documentation clarifying the workflow source and merge queue requirements.
  * These updates help ensure changes meet required validation checks before entering the merge queue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->