### PR TITLE
Add osac-ci-bot to fulfillment-wg

### DIFF
--- a/team-members/fulfillment-wg.csv
+++ b/team-members/fulfillment-wg.csv
@@ -78,3 +78,4 @@ srasanen,member
 mvaskima,member
 sank-ak,member
 mor-rh,member
+osac-ci-bot,member


### PR DESCRIPTION
## Problem

`osac-ci-bot` runs the merge-queue automation in `osac-project/osac`:
- `auto-queue.yml`: removes `lgtm` on push, dismisses changes-requested reviews, checks collaborator status, enables/disables auto-merge
- `konflux-auto-label.yml`: labels Konflux dependency-bump PRs

It wasn't a member of any team here, so it had no path to elevated repo access and fell back to the org default (`read`). **A fine-grained PAT owned by this account can never exceed its actual collaborator role, regardless of what permissions the token itself requests** — confirmed live against the real API: every mutating call (label add, review dismiss, collaborator check, auto-merge enable/disable) returned 403, even after configuring the token's own fine-grained permissions correctly (`Contents: write`, `Pull requests: write`, `Administration: read`) and getting it approved by an org owner.

## Fix

One line: add `osac-ci-bot` to `fulfillment-wg` in `team-members/fulfillment-wg.csv`. That team already grants `push` on `osac`, `osac-test-infra`, and `github-config` (among others) — matching what the existing `MERGE_QUEUE_TOKEN` (a personal token) effectively has today. `osac-dev-bot`, another bot account, is already a plain member of this same team, so this isn't a new pattern.

## Verification

- [x] `tofu fmt -check` — clean (no formatting changes needed, plain CSV edit)
- [x] `tofu validate` — succeeds (only pre-existing, unrelated deprecation warnings)
- [x] Confirmed `osac-ci-bot` is already an org member (`members.csv`) and not currently in any team (`team-members/*.csv`) before this change
- [x] Confirmed via the live API (`GET /repos/osac-project/osac/collaborators/osac-ci-bot/permission`) that its current effective permission is `read`, consistent with having no team-based grant anywhere