### PR TITLE
Require osac merge-group-safe pre-commit, unit, and integration checks

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -155,6 +155,18 @@ module "repo_osac" {
     # Reads Prow-set labels (lgtm, approved, jira/valid-reference) and converts
     # them to a status check the merge queue can gate on.
     { context = "check-labels", integration_id = 15368 },
+    # Names match GitHub Actions job `name:` (or job id if unnamed). Job-level
+    # `if:` skips report success, so docs-only PRs are not blocked.
+    { context = "pre-commit", integration_id = 15368 },
+    { context = "Run unit tests", integration_id = 15368 },
+    { context = "Run unit tests (osac-metering)", integration_id = 15368 },
+    { context = "Run unit tests (osac-metering/adapters)", integration_id = 15368 },
+    { context = "Run unit tests (osac-metering/schema)", integration_id = 15368 },
+    { context = "Run integration test (fulfillment-service)", integration_id = 15368 },
+    { context = "Run integration test (osac-operator)", integration_id = 15368 },
+    { context = "Run integration test (bare-metal-fulfillment-operator)", integration_id = 15368 },
+    { context = "Run integration test (osac-aap)", integration_id = 15368 },
+    { context = "Run integration test (osac-installer)", integration_id = 15368 },
   ]
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
 


### PR DESCRIPTION
## Summary
- add the merge-group-safe `osac` pre-commit, unit, and integration jobs to the required status check list
- keep the ruleset limited to checks that actually report on `merge_group`
- leave PR-only checks like `CodeQL`, `dependency-review`, and generated-code jobs out of the merge queue ruleset

## Test plan
- [x] `tofu validate`
- [ ] queue one `osac` PR and confirm the added checks report on the merge-group commit

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added required status checks for pre-commit, unit tests, and integration tests across OSAC components.
  * Updated the repository state reference for the OSAC metering service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->