### PR TITLE
Require all osac CI checks in merge gate

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -155,6 +155,20 @@ module "repo_osac" {
     # Reads Prow-set labels (lgtm, approved, jira/valid-reference) and converts
     # them to a status check the merge queue can gate on.
     { context = "check-labels", integration_id = 15368 },
+    # Names match GitHub Actions job `name:` (or job id if unnamed). Job-level
+    # `if:` skips report success, so docs-only PRs are not blocked.
+    { context = "pre-commit", integration_id = 15368 },
+    { context = "Check generated code (fulfillment-service)", integration_id = 15368 },
+    { context = "Check generated code (osac-operator)", integration_id = 15368 },
+    { context = "Run unit tests", integration_id = 15368 },
+    { context = "Run unit tests (osac-metering)", integration_id = 15368 },
+    { context = "Run unit tests (osac-metering/adapters)", integration_id = 15368 },
+    { context = "Run unit tests (osac-metering/schema)", integration_id = 15368 },
+    { context = "Run integration test (fulfillment-service)", integration_id = 15368 },
+    { context = "Run integration test (osac-operator)", integration_id = 15368 },
+    { context = "Run integration test (osac-aap)", integration_id = 15368 },
+    { context = "Run integration test (osac-installer)", integration_id = 15368 },
+    { context = "Run integration test (bare-metal-fulfillment-operator)", integration_id = 15368 },
   ]
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
 


### PR DESCRIPTION
## Summary
- Add pre-commit, generated-code, unit, and integration jobs to the `osac` merge-queue required checks
- Keep existing e2e gates and `check-labels`
- Job-level `if:` skips still report success, so docs-only PRs are not blocked

## Test plan
- [ ] Confirm check context names match osac GitHub Actions job `name:` (or job id if unnamed)
- [ ] Confirm docs-only PRs still pass via job-level `if:` skips

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated status checks to the `repo_osac` merge queue for code formatting, generated-code validation, unit tests, and integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->