### PR TITLE
Require remaining osac CI checks in merge gate

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -169,6 +169,20 @@ module "repo_osac" {
     { context = "Run integration test (osac-aap)", integration_id = 15368 },
     { context = "Run integration test (osac-installer)", integration_id = 15368 },
     { context = "Run integration test (bare-metal-fulfillment-operator)", integration_id = 15368 },
+    # Cheap lints and component unit tests. Step skip reports success when
+    # that path did not change, so unrelated PRs are not blocked.
+    { context = "ansible-lint", integration_id = 15368 },
+    { context = "Check generated code (osac-metering/metering-service)", integration_id = 15368 },
+    { context = "Check Python code", integration_id = 15368 },
+    { context = "Check Go and proto code", integration_id = 15368 },
+    { context = "Build binaries", integration_id = 15368 },
+    { context = "dependency-review", integration_id = 15368 },
+    { context = "Lint Helm charts (osac-installer)", integration_id = 15368 },
+    { context = "Check Helm CRD sync (osac-operator)", integration_id = 15368 },
+    { context = "Check Helm CRD sync (bare-metal-fulfillment-operator)", integration_id = 15368 },
+    { context = "Run darwin keychain tests", integration_id = 15368 },
+    { context = "Run unit tests (osac-operator)", integration_id = 15368 },
+    { context = "Run unit tests (bare-metal-fulfillment-operator)", integration_id = 15368 },
   ]
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
 


### PR DESCRIPTION
## Summary
- Add remaining cheap osac CI jobs to `repo_osac` merge-queue required checks
- Covers ansible-lint, FS python/go/binaries, helm CRD sync, installer helm lint, darwin keychain, operator/BMF unit tests, metering generated-code, dependency-review
- Step skip still reports success, so unrelated PRs are not blocked

Wait for [osac-project/osac#717](https://github.com/osac-project/osac/pull/717) to merge first. Those workflows must always report these names on `pull_request`/`merge_group`; applying this ruleset earlier leaves the merge queue waiting for checks that never start.

## Test plan
- [ ] Merge osac#717 first
- [ ] Context names match osac GitHub Actions job `name:` (or job id if unnamed)
- [ ] Docs-only / unrelated-component PRs still merge (names report, work skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI:** Added inexpensive `repo_osac` merge-queue required checks for:
  - Ansible linting.
  - Python, Go, and binary filesystem checks.
  - Helm CRD synchronization and installer Helm linting.
  - Darwin keychain tests.
  - Operator and bare-metal operator unit tests.
  - Metering generated code.
  - Dependency review.
- Skipped jobs continue to report success. Documentation-only and unrelated pull requests remain unblocked.
- **API surface, controllers, database, auth, deployment, tests, and documentation:** No production or public API changes. The test-related changes affect CI coverage only.

## Compatibility

No backward-compatibility impact is expected. The change updates required CI checks and does not modify runtime behavior, interfaces, or deployment artifacts.

## Risk classification

**risk:ship** — The change is limited to CI configuration and adds validation checks without changing production code or runtime behavior. It does not qualify for **risk:show** because it introduces no user-visible feature or operational behavior change. It does not qualify for **risk:ask** because it does not alter security controls, data handling, APIs, or production infrastructure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
