### PR TITLE
Revert "Require remaining osac CI checks in merge gate"

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -169,20 +169,6 @@ module "repo_osac" {
     { context = "Run integration test (osac-aap)", integration_id = 15368 },
     { context = "Run integration test (osac-installer)", integration_id = 15368 },
     { context = "Run integration test (bare-metal-fulfillment-operator)", integration_id = 15368 },
-    # Cheap lints and component unit tests. Step skip reports success when
-    # that path did not change, so unrelated PRs are not blocked.
-    { context = "ansible-lint", integration_id = 15368 },
-    { context = "Check generated code (osac-metering/metering-service)", integration_id = 15368 },
-    { context = "Check Python code", integration_id = 15368 },
-    { context = "Check Go and proto code", integration_id = 15368 },
-    { context = "Build binaries", integration_id = 15368 },
-    { context = "dependency-review", integration_id = 15368 },
-    { context = "Lint Helm charts (osac-installer)", integration_id = 15368 },
-    { context = "Check Helm CRD sync (osac-operator)", integration_id = 15368 },
-    { context = "Check Helm CRD sync (bare-metal-fulfillment-operator)", integration_id = 15368 },
-    { context = "Run darwin keychain tests", integration_id = 15368 },
-    { context = "Run unit tests (osac-operator)", integration_id = 15368 },
-    { context = "Run unit tests (bare-metal-fulfillment-operator)", integration_id = 15368 },
   ]
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
 


### PR DESCRIPTION
Reverts osac-project/github-config#205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI:** Reverts the remaining required status checks for the `osac` repository merge queue. The merge gate now requires only the remaining integration-test, pre-commit, and generated-code checks.
- **API surface, controllers, database, auth, deployment, tests, documentation:** No changes.

## Backward compatibility

This change affects merge-gate enforcement only. It does not change runtime behavior, APIs, deployed resources, or stored data. It reduces CI protection because 12 checks are no longer required for merging.

## Risk classification

**risk:ship** — Configuration-only change with no runtime, API, deployment, database, or security impact. It is close to **risk:show** because it weakens required CI checks, but it does not alter application behavior or production systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->