### PR TITLE
Require remaining osac CI checks in merge gate

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -169,6 +169,20 @@ module "repo_osac" {
     { context = "Run integration test (osac-aap)", integration_id = 15368 },
     { context = "Run integration test (osac-installer)", integration_id = 15368 },
     { context = "Run integration test (bare-metal-fulfillment-operator)", integration_id = 15368 },
+    # Cheap lints and component unit tests. Step skip reports success when
+    # that path did not change, so unrelated PRs are not blocked.
+    { context = "ansible-lint", integration_id = 15368 },
+    { context = "Check generated code (osac-metering/metering-service)", integration_id = 15368 },
+    { context = "Check Python code", integration_id = 15368 },
+    { context = "Check Go and proto code", integration_id = 15368 },
+    { context = "Build binaries", integration_id = 15368 },
+    { context = "dependency-review", integration_id = 15368 },
+    { context = "Lint Helm charts (osac-installer)", integration_id = 15368 },
+    { context = "Check Helm CRD sync (osac-operator)", integration_id = 15368 },
+    { context = "Check Helm CRD sync (bare-metal-fulfillment-operator)", integration_id = 15368 },
+    { context = "Run darwin keychain tests", integration_id = 15368 },
+    { context = "Run unit tests (osac-operator)", integration_id = 15368 },
+    { context = "Run unit tests (bare-metal-fulfillment-operator)", integration_id = 15368 },
   ]
   ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
 


### PR DESCRIPTION
## Summary
- Resubmit of #205 after #206 revert, now that [osac-project/osac#717](https://github.com/osac-project/osac/pull/717) is merged
- Add remaining cheap osac CI jobs to `repo_osac` merge-queue required checks
- Covers ansible-lint, FS python/go/binaries, helm CRD sync, installer helm lint, darwin keychain, operator/BMF unit tests, metering generated-code, dependency-review
- Step skip still reports success, so unrelated PRs are not blocked

osac#717 makes those workflows always report these names on `pull_request`/`merge_group`. Applying this ruleset before that left the merge queue waiting for checks that never started.

## Jira
N/A

## Test plan
- [x] osac#717 merged
- [ ] Context names match osac GitHub Actions job `name:` (or job id if unnamed)
- [ ] Docs-only / unrelated-component PRs still merge (names report, work skipped)

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.1.3). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI:** Adds inexpensive `repo_osac` merge-queue required checks for linting, filesystem language and binary checks, Helm validation, Darwin keychain tests, operator and BMF unit tests, metering generated code, and dependency review.
- **CI behavior:** Skipped jobs still report success. Unrelated pull requests remain unblocked.
- **API surface, controllers, database, auth, deployment, tests, documentation:** No direct changes.
- **Backward compatibility:** No runtime or API compatibility impact. The change can affect merge eligibility when a required check fails.

## Risk classification

**risk:ship** — The change only updates CI required-check declarations. It does not change runtime code, deployment behavior, data, authentication, or public interfaces. It is close to **risk:show** because required checks can affect merge workflows, but it does not meet that threshold because the checks are inexpensive and skipped steps report success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->