### PR TITLE
NO-ISSUE: Require EP review-gate and pre-commit checks

### DIFF
--- a/modules/common_repository/labels.csv
+++ b/modules/common_repository/labels.csv
@@ -20,3 +20,4 @@ p0,e94f24,Highest priority
 p1,ffc600,Medium priority
 p2,cfd8dc,Low priority
 security,ff0000,This is a security issue
+do-not-merge/hold,ededed,Block merge until the label is removed

--- a/repositories.tf
+++ b/repositories.tf
@@ -313,6 +313,13 @@ module "repo_enhancement_proposals" {
   description            = "A repository for proposing enhancements to the osac project"
   all_members_permission = "push"
   required_approvals     = 2
+  required_status_checks = [
+    # Job id in enhancement-proposals/.github/workflows/review-gate.yml.
+    { context = "check-human-reviews", integration_id = 15368 },
+    # Job id in enhancement-proposals/.github/workflows/pre-commit.yaml.
+    { context = "pre-commit", integration_id = 15368 },
+  ]
+  ruleset_bypass_team_ids = [github_team.all["wg-infra"].id]
 }
 
 module "repo_osac_test_infra" {


### PR DESCRIPTION
## Summary
- Adds `ci-status-checks` ruleset for `enhancement-proposals` with `check-human-reviews` and `pre-commit`.
- Grants `wg-infra` ruleset bypass for infra/admin override.

## Dependency
**Merge osac-project/enhancement-proposals#257 first.** That PR adds `.github/workflows/review-gate.yml`; the check must run at least once before the ruleset context exists. Do not apply this until #257 is on `main`.

## Jira
N/A

## Test plan
- [ ] After EP #257 merges, open a test PR on enhancement-proposals and confirm both checks report
- [ ] Human Request changes fails `check-human-reviews`
- [ ] `tofu plan` clean on apply

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Affected areas

- **CI:** Requires `check-human-reviews` and `pre-commit` for `enhancement-proposals`.
- **Access control:** Grants `wg-infra` a ruleset bypass.
- **Deployment:** The review-gate workflow must exist on `main` before applying the ruleset.
- **API, controllers, database, tests, and documentation:** No changes.

## Compatibility

The ruleset can block merges when either check is missing or fails. The scoped `wg-infra` bypass preserves infrastructure and administrative overrides.

## Risk classification

**risk:show** — The change affects CI enforcement and repository access control, but not runtime behavior or production data. It does not meet the higher **risk:ask** threshold because the change is limited to repository governance. It is above **risk:ship** because an incorrect check context can block merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->